### PR TITLE
REPLACED MAX_CONTROLLERS_NUMBER and CAN_CONTROLLERS_NUMBER with USED_…

### DIFF
--- a/Software/bsw/gen/Can_Cfg.h
+++ b/Software/bsw/gen/Can_Cfg.h
@@ -43,8 +43,7 @@
 
 #define MAX_BAUDRATE_CONFIGS_CONTROLLER_0 	     (1U)
 #define MAX_BAUDRATE_CONFIGS_CONTROLLER_1	     (1U)
-#define MAX_CONTROLLERS_NUMBER                   (2U)
-#define CAN_CONTROLLERS_NUMBER                   (1U)                /*number of can controllers in the ECU*/
+#define USED_CONTROLLERS_NUMBER                  (1U)                /*number of can controllers in the ECU*/
 #define CAN_HOH_NUMBER                           (2U)
 #define CAN_HRH_NUMBER                           (1U)
 #define CAN_HTH_NUMBER                           (1U)

--- a/Software/bsw/static/Infrastructure/inc/Can_GeneralTypes.h
+++ b/Software/bsw/static/Infrastructure/inc/Can_GeneralTypes.h
@@ -72,8 +72,8 @@ typedef uint8 Can_ControllerStateType;
 */
 typedef uint8 Can_ErrorStateType ;
 #define CAN_ERRORSTATE_ACTIVE  ((Can_ErrorStateType) 0x00U)  
-#define CAN_ERRORSTATE_PASSIVE ((Can_ErrorStateType) 0x01U)  
-#define CAN_ERRORSTATE_BUSOFF  ((Can_ErrorStateType) 0x02U)  
+#define CAN_ERRORSTATE_PASSIVE ((Can_ErrorStateType) 0x20U)
+#define CAN_ERRORSTATE_BUSOFF  ((Can_ErrorStateType) 0xA0U)
 
 
 /*


### PR DESCRIPTION
REPLACED MAX_CONTROLLERS_NUMBER and CAN_CONTROLLERS_NUMBER with USED_CONTROLLERS_NUMBER to represent number of used controllers (Can_Cfg.h)

CHANGED the values of CAN_ERRORSTATE_PASSIVE and CAN_ERRORSTATE_BUSOFF flags
to match datasheet (Can_GeneralTypes.h)

FIXED  Can_GetControllerErrorState() logic errors  (Can.c)