### PR TITLE
Can_Write_Fix PullReq

### DIFF
--- a/Software/bsw/gen/Can_Cfg.h
+++ b/Software/bsw/gen/Can_Cfg.h
@@ -35,6 +35,7 @@
 /*                                   Include headres                                     */
 /*****************************************************************************************/
 #include "Can_PBcfg.h"
+#include "Std_Types.h"
 /*****************************************************************************************/
 /*                                    Macro Definition                                   */
 /*****************************************************************************************/
@@ -100,7 +101,6 @@
 /*Non-Autosar file*/
 #include "tm4c123gh6pm.h"
 
-#include "Std_Types.h"
 /* AUTOSAR checking between Std Types and Can_Cfg Modules */
 #if ((STD_TYPES_AR_RELEASE_MAJOR_VERSION != CAN_CFG_AR_RELEASE_MAJOR_VERSION)\
  ||  (STD_TYPES_AR_RELEASE_MINOR_VERSION != CAN_CFG_AR_RELEASE_MINOR_VERSION)\

--- a/Software/bsw/static/Mcal/CAN/src/Can.c
+++ b/Software/bsw/static/Mcal/CAN/src/Can.c
@@ -719,6 +719,9 @@ void Can_EnableControllerInterrupts(uint8 Controller) {
         else {
         }
     }
+	else
+	{
+	}
     /* End of Critical Section */
 	irq_Enable();
 }
@@ -802,15 +805,18 @@ void Can_DeInit(void) {
     {
         Det_ReportError(CAN_MODULE_ID, CAN_INSTANCE_ID, Can_DeInit_Id, CAN_E_TRANSITION);
     }
-    /*  The function Can_DeInit shall raise the error CAN_E_TRANSITION if any of the CAN
-     *  controllers is in state STARTED [SWS_Can_91012]
-     */
-    if (CAN_CS_STARTED == ControllerState[0]
-            || CAN_CS_STARTED == ControllerState[1])
-    {
-        Det_ReportError(CAN_MODULE_ID, CAN_INSTANCE_ID, Can_DeInit_Id,
-                CAN_E_TRANSITION);
-    }
+	uint8 ControllerIndex = 0 ;
+	for(ControllerIndex = 0; ControllerIndex < USED_CONTROLLERS_NUMBER; ControllerIndex++)
+	{
+		/*  The function Can_DeInit shall raise the error CAN_E_TRANSITION if any of the CAN
+		 *  controllers is in state STARTED [SWS_Can_91012]
+		 */
+		if (CAN_CS_STARTED == ControllerState[ControllerIndex])
+		{
+			Det_ReportError(CAN_MODULE_ID, CAN_INSTANCE_ID, Can_DeInit_Id,
+					CAN_E_TRANSITION);
+		}
+	}
 #endif
     /*  [SWS_Can_ 91009] The function Can_DeInit shall change the module state to
      *  CAN_UNINIT before de-initializing all controllers inside the HW unit
@@ -818,11 +824,12 @@ void Can_DeInit(void) {
      *  The state of a BSW Module shall be set accordingly at the beginning of the DeInitialization function
      */
     ModuleState = CAN_UNINIT;
-	/*	Disable the first four bits in CAN Control Register in both controllers */
-    CLR_BITS( HWREG(CAN0_BASE + CAN_O_CTL),0
-             , CAN_CTL_INIT | CAN_CTL_IE | CAN_CTL_SIE | CAN_CTL_EIE );   // DeInit CAN controller0
-    CLR_BITS( HWREG(CAN1_BASE + CAN_O_CTL),0
-             , CAN_CTL_INIT | CAN_CTL_IE | CAN_CTL_SIE | CAN_CTL_EIE );  // DeInit CAN controller1
+	for(ControllerIndex = 0; ControllerIndex < USED_CONTROLLERS_NUMBER; ControllerIndex++)
+	{
+		/*	Disable the first four bits in CAN Control Register in both controllers */
+		CLR_BITS( HWREG(Global_Config->CanHardwareObjectRef[ControllerIndex].CanControllerRef->CanControllerBaseAddress + CAN_O_CTL),0
+				 , CAN_CTL_INIT | CAN_CTL_IE | CAN_CTL_SIE | CAN_CTL_EIE );   // DeInit CAN controller of ControllerIndex
+	}
 }
 
 void Can_MainFunction_Read(void) {

--- a/Software/bsw/static/Mcal/CAN/src/Can.c
+++ b/Software/bsw/static/Mcal/CAN/src/Can.c
@@ -708,16 +708,9 @@ void Can_EnableControllerInterrupts(uint8 Controller) {
         /* [SWS_Can_00050] The function Can_EnableControllerInterrupts shall enable all
          * interrupts that must be enabled according the current software status
          */
-		/*  Enable the first CAN Controller Interrupts */ 
-        if (CAN0_ID == Controller)
-            CANIntEnable(CAN0_BASE,
-                    CAN_CTL_EIE | CAN_CTL_SIE | CAN_CTL_IE);
-        /*  Enable the second CAN Controller Interrupts */ 
-		else if (CAN1_ID == Controller)
-            CANIntEnable(CAN1_BASE,
-                    CAN_CTL_EIE | CAN_CTL_SIE | CAN_CTL_IE);
-        else {
-        }
+		/*  Enable the specified CAN Controller Interrupts */
+		CANIntEnable(Global_Config->CanHardwareObjectRef[Controller].CanControllerRef->CanControllerBaseAddress,
+				CAN_CTL_EIE | CAN_CTL_SIE | CAN_CTL_IE);
     }
 	else
 	{
@@ -768,16 +761,9 @@ void Can_DisableControllerInterrupts(uint8 Controller) {
          *  CAN controller registers to disable all interrupts for that CAN controller only, if
          *  interrupts for that CAN Controller are enabled
          */
-        /*  Disable the first CAN Controller Interrupts */ 
-        if (CAN0_ID == Controller)
-            CANIntDisable(CAN0_BASE,
-                    CAN_CTL_EIE | CAN_CTL_SIE | CAN_CTL_IE);
-        /*  Disable the second CAN Controller Interrupts */ 
-		else if (CAN1_ID == Controller)
-            CANIntDisable(CAN1_BASE,
-                    CAN_CTL_EIE | CAN_CTL_SIE | CAN_CTL_IE);
-        else {
-        }
+        /*  Disable the specified CAN Controller Interrupts */
+		CANIntDisable(Global_Config->CanHardwareObjectRef[Controller].CanControllerRef->CanControllerBaseAddress,
+				CAN_CTL_EIE | CAN_CTL_SIE | CAN_CTL_IE);
     }
     DisableCnt[Controller]++;
 


### PR DESCRIPTION
1- Det_ReportError function is called not left as a comment.
2- ui32Base , hth_index , Hth_count , Hoh_count and real_hwObjectId are defined with zeros not declared only.
3- Made #endif correct as it was used in a wrong way.
4- including Std_Types.h before using STD_ON which is defined in Std_Types.h , While STD_ON was used in Can_Cfg.h before including Std_Types.h .
5- Edited the blocking loop problem, [SWS_Can_00275] The function Can_Write shall be non-blocking, while it is blocking to check CANIF1CRQ register.
6- Edited the code to perform no actions if the hardware transmit object is busy and return CAN_BUSY as [SWS_Can_00213] says.