### PR TITLE
Can if containers

### DIFF
--- a/Software/bsw/gen/CanIf_Cfg.h
+++ b/Software/bsw/gen/CanIf_Cfg.h
@@ -375,19 +375,19 @@ the name of the API <User_TriggerTransmit>() has to be configured via parameter 
 #if(CANIF_TX_PDU_TRIGGER_TRANSMIT==STD_ON)
 	#if(CanIfTxPduUserTxConfirmationUL==PDUR)
 		#define CANIF_TX_PDU_USER_TRIGGER_TRANSMIT_NAME	PduR_CanIfTriggerTransmit
-	#else if(CanIfTxPduUserTxConfirmationUL==CAN_NM)
+	#elif(CanIfTxPduUserTxConfirmationUL==CAN_NM)
 		#define CANIF_TX_PDU_USER_TRIGGER_TRANSMIT_NAME	CanNm_CanIfTriggerTransmit
-	#else if(CanIfTxPduUserTxConfirmationUL==J1939NM)
+	#elif(CanIfTxPduUserTxConfirmationUL==J1939NM)
 		#define CANIF_TX_PDU_USER_TRIGGER_TRANSMIT_NAME	J1939Nm_CanIfTriggerTransmit
-	#else if(CanIfTxPduUserTxConfirmationUL==J1939TP)
+	#elif(CanIfTxPduUserTxConfirmationUL==J1939TP)
 		#define CANIF_TX_PDU_USER_TRIGGER_TRANSMIT_NAME	J1939Tp_CanIfTriggerTransmit
-	#else if(CanIfTxPduUserTxConfirmationUL==CAN_TP)
+	#elif(CanIfTxPduUserTxConfirmationUL==CAN_TP)
 		#define CANIF_TX_PDU_USER_TRIGGER_TRANSMIT_NAME	CanTp_CanIfTriggerTransmit
-	#else if(CanIfTxPduUserTxConfirmationUL==XCP)
+	#elif(CanIfTxPduUserTxConfirmationUL==XCP)
 		#define CANIF_TX_PDU_USER_TRIGGER_TRANSMIT_NAME	Xcp_CanIfTriggerTransmit
-	#else if(CanIfTxPduUserTxConfirmationUL==CAN_TSYN)
+	#elif(CanIfTxPduUserTxConfirmationUL==CAN_TSYN)
 		#define CANIF_TX_PDU_USER_TRIGGER_TRANSMIT_NAME	CanTSyn_CanIfTriggerTransmit
-	#else if(CanIfTxPduUserTxConfirmationUL==CDD)
+	#elif(CanIfTxPduUserTxConfirmationUL==CDD)
 		#define CANIF_TX_PDU_USER_TRIGGER_TRANSMIT_NAME	Cdd_CanIfTriggerTransmit /* Selectable */
 	#endif	
 #endif
@@ -409,19 +409,19 @@ is set to CDD, the name of the API <User_TriggerTransmit>() has to be configured
 #if(CANIF_TX_PDU_TRIGGER_TRANSMIT==STD_ON)
 	#if(CanIfTxPduUserTxConfirmationUL==PDUR)
 		#define CANIF_TX_PDU_USER_TX_CONFIRMATION_NAME	PduR_CanIfTxConfirmation
-	#else if(CanIfTxPduUserTxConfirmationUL==CAN_NM)
+	#elif(CanIfTxPduUserTxConfirmationUL==CAN_NM)
 		#define CANIF_TX_PDU_USER_TX_CONFIRMATION_NAME	CanNm_TxConfirmation
-	#else if(CanIfTxPduUserTxConfirmationUL==J1939NM)
+	#elif(CanIfTxPduUserTxConfirmationUL==J1939NM)
 		#define CANIF_TX_PDU_USER_TX_CONFIRMATION_NAME	J1939Nm_TxConfirmation
-	#else if(CanIfTxPduUserTxConfirmationUL==J1939TP)
+	#elif(CanIfTxPduUserTxConfirmationUL==J1939TP)
 		#define CANIF_TX_PDU_USER_TX_CONFIRMATION_NAME	J1939Tp_TxConfirmation
-	#else if(CanIfTxPduUserTxConfirmationUL==CAN_TP)
+	#elif(CanIfTxPduUserTxConfirmationUL==CAN_TP)
 		#define CANIF_TX_PDU_USER_TX_CONFIRMATION_NAME	CanTp_TxConfirmation
-	#else if(CanIfTxPduUserTxConfirmationUL==XCP)
+	#elif(CanIfTxPduUserTxConfirmationUL==XCP)
 		#define CANIF_TX_PDU_USER_TX_CONFIRMATION_NAME	Xcp_CanIfTxConfirmation
-	#else if(CanIfTxPduUserTxConfirmationUL==CAN_TSYN)
+	#elif(CanIfTxPduUserTxConfirmationUL==CAN_TSYN)
 		#define CANIF_TX_PDU_USER_TX_CONFIRMATION_NAME	CanTSyn_CanIfTxConfirmation
-	#else if(CanIfTxPduUserTxConfirmationUL==CDD)
+	#elif(CanIfTxPduUserTxConfirmationUL==CDD)
 		#define CANIF_TX_PDU_USER_TX_CONFIRMATION_NAME	Cdd_CanIfTxConfirmation /* Selectable */
 	#endif	
 #endif
@@ -532,19 +532,19 @@ for receive indications and thus <User_RxIndication>() shall not be called, CANI
 and CANIF_RXPDU_USERRXINDICATION_NAME need not to be configured. */
 #if(CanIfRxPduUserRxIndicationUL==PDUR)
 	#define CANIF_RX_PDU_USER_RX_INDICATION_NAME	PduR_CanIfRxIndication
-#else if(CanIfRxPduUserRxIndicationUL==CAN_NM)
+#elif(CanIfRxPduUserRxIndicationUL==CAN_NM)
 	#define CANIF_RX_PDU_USER_RX_INDICATION_NAME	CanNm_RxIndication
-#else if(CanIfRxPduUserRxIndicationUL==J1939NM)
+#elif(CanIfRxPduUserRxIndicationUL==J1939NM)
 	#define CANIF_RX_PDU_USER_RX_INDICATION_NAME	J1939Nm_RxIndication
-#else if(CanIfRxPduUserRxIndicationUL==J1939TP)
+#elif(CanIfRxPduUserRxIndicationUL==J1939TP)
 	#define CANIF_RX_PDU_USER_RX_INDICATION_NAME	J1939Tp_RxIndication
-#else if(CanIfRxPduUserRxIndicationUL==CAN_TP)
+#elif(CanIfRxPduUserRxIndicationUL==CAN_TP)
 	#define CANIF_RX_PDU_USER_RX_INDICATION_NAME	CanTp_RxIndication
-#else if(CanIfRxPduUserRxIndicationUL==XCP)
+#elif(CanIfRxPduUserRxIndicationUL==XCP)
 	#define CANIF_RX_PDU_USER_RX_INDICATION_NAME	Xcp_CanIfRxIndication
-#else if(CanIfRxPduUserRxIndicationUL==CAN_TSYN)
+#elif(CanIfRxPduUserRxIndicationUL==CAN_TSYN)
 	#define CANIF_RX_PDU_USER_RX_INDICATION_NAME	CanTSyn_CanIfRxIndication
-#else if(CanIfRxPduUserRxIndicationUL==CDD)
+#elif(CanIfRxPduUserRxIndicationUL==CDD)
 	#define CANIF_RX_PDU_USER_RX_INDICATION_NAME	Cdd_CanIfRxIndication /* Selectable */
 #endif	
 
@@ -575,7 +575,7 @@ dependency: CANIF_DISPATCH_USERCHECKTRCVWAKEFLAGINDICATION_UL, CANIF_PUBLIC_PN_S
 #if(CANIF_PUBLIC_PN_SUPPORT==STD_ON)
 	#if(CanIfDispatchUserCheckTrcvWakeFlagIndicationUL==CAN_SM)
 		#define CANIF_DISPATCH_USER_CHECK_TRCV_WAKE_FLAG_INDICATION_NAME 	CanSM_CheckTrcvWakeFlagIndication
-	#else if(CanIfDispatchUserCheckTrcvWakeFlagIndicationUL==CDD)
+	#elif(CanIfDispatchUserCheckTrcvWakeFlagIndicationUL==CDD)
 		#define CANIF_DISPATCH_USER_CHECK_TRCV_WAKE_FLAG_INDICATION_NAME	Cdd_CheckTrcvWakeFlagIndication
 	#endif
 #endif
@@ -596,7 +596,7 @@ If CANIF_PUBLIC_PN_SUPPORT equals False, this parameter shall not be configurabl
 #if(CANIF_PUBLIC_PN_SUPPORT==STD_ON)
 	#if(CanIfDispatchUserClearTrcvWufFlagIndicationUL==CAN_SM)
 		#define CANIF_DISPATCH_USER_CLEAR_TRCV_WUF_FLAG_INDICATION_NAME		CanSM_ClearTrcvWufFlagIndication
-	#else if(CanIfDispatchUserClearTrcvWufFlagIndicationUL==CDD)
+	#elif(CanIfDispatchUserClearTrcvWufFlagIndicationUL==CDD)
 		#define CANIF_DISPATCH_USER_CLEAR_TRCV_WUF_FLAG_INDICATION_NAME		Cdd_ClearTrcvWufFlagIndication
 	#endif
 #endif
@@ -617,7 +617,7 @@ If CANIF_PUBLIC_PN_SUPPORT equals False, this parameter shall not be configurabl
 #if(CANIF_PUBLIC_PN_SUPPORT==STD_ON)
 	#if(CanIfDispatchUserConfirmPnAvailabilityUL==CAN_SM)
 		#define CANIF_DISPATCH_USER_CONFIRM_PN_AVAILABILITY_NAME		CanSM_ConfirmPnAvailability
-	#else if(CanIfDispatchUserConfirmPnAvailabilityUL==CDD)
+	#elif(CanIfDispatchUserConfirmPnAvailabilityUL==CDD)
 		#define CANIF_DISPATCH_USER_CONFIRM_PN_AVAILABILITY_NAME		Cdd_ConfirmPnAvailability
 	#endif
 #endif
@@ -634,7 +634,7 @@ CANIF_USERCTRLBUSOFF_UL. If CANIF_USERCTRLBUSOFF_UL equals CAN_SM the name of <U
 is fixed. If CANIF_USERCTRLBUSOFF_UL equals CDD, the name of <User_ControllerBusOff> is selectable. */
 #if(CanIfDispatchUserCtrlBusOffUL==CAN_SM)
 	#define CANIF_DISPATCH__USER_CTRL_BUS_OFF_NAME					CanSM_ControllerBusOff
-#else if(CanIfDispatchUserCtrlBusOffUL==CDD)
+#elif(CanIfDispatchUserCtrlBusOffUL==CDD)
 	#define CANIF_DISPATCH__USER_CTRL_BUS_OFF_NAME					Cdd_ControllerBusOff
 #endif
 
@@ -649,7 +649,7 @@ CANIF_USERCTRLMODEINDICATION_UL. If CANIF_USERCTRLMODEINDICATION_UL equals CAN_S
 is fixed. If CANIF_USERCTRLMODEINDICATION_UL equals CDD, the name of <User_ControllerModeIndication> is selectable. */
 #if(CanIfDispatchUserCtrlModeIndicationUL==CAN_SM)
 	#define CANIF_DISPATCH_USER_CTRL_MODE_INDICATION_NAME			CanSM_ControllerModeIndication
-#else if(CanIfDispatchUserCtrlModeIndicationUL==CDD)
+#elif(CanIfDispatchUserCtrlModeIndicationUL==CDD)
 	#define CANIF_DISPATCH_USER_CTRL_MODE_INDICATION_NAME			Cdd_ControllerModeIndication
 #endif
 
@@ -665,7 +665,7 @@ CANIF_USERTRCVMODEINDICATION_UL. If CANIF_USERTRCVMODEINDICATION_UL equals CAN_S
 is fixed. If CANIF_USERTRCVMODEINDICATION_UL equals CDD, the name of <User_TrcvModeIndication> is selectable. */
 #if(CanIfDispatchUserTrcvModeIndicationUL==CAN_SM)
 	#define CANIF_DISPATCH_USER_TRCV_MODE_INDICATION_NAME			CanSM_TransceiverModeIndication
-#else if(CanIfDispatchUserTrcvModeIndicationUL==CDD)
+#elif(CanIfDispatchUserTrcvModeIndicationUL==CDD)
 	#define CANIF_DISPATCH_USER_TRCV_MODE_INDICATION_NAME			Cdd_TransceiverModeIndication
 #endif
 
@@ -685,7 +685,7 @@ CANIF_WAKEUP_CHECK_VALIDATION_API is disabled, no <User_ValidateWakeupEvent> API
 #if(CANIF_PUBLIC_WAKEUP_CHECK_VALID_SUPPORT==STD_ON)
 	#if(CanIfDispatchUserValidateWakeupEventUL==ECUM)
 		#define CANIF_DISPATCH_USER_VALIDATE_WAKEUP_EVENT_NAME		EcuM_ValidateWakeupEvent
-	#else if(CanIfDispatchUserValidateWakeupEventUL==CDD)
+	#elif(CanIfDispatchUserValidateWakeupEventUL==CDD)
 		#define CANIF_DISPATCH_USER_VALIDATE_WAKEUP_EVENT_NAME		Cdd_ValidateWakeupEvent
 	#endif
 #endif
@@ -761,7 +761,7 @@ Txbuffer. If CanIfPublicTxBuffering equals False, this parameter equals
 FULL, this parameter equals 0 for this TxBuffer.*/
 #if(CANIF_PUBLIC_TX_BUFFERING==STD_OFF)
 	#define CANIF_BUFFER_SIZE                  (0U)
-#else if(CanHardwareObject.CanHandleType==FULL)
+#elif(CanHardwareObject.CanHandleType==FULL)
 	#define CANIF_BUFFER_SIZE                  (0U)
 #else	/* any value, implementation dependant */
 	#define CANIF_BUFFER_SIZE                  (255U)

--- a/Software/bsw/gen/CanIf_Cfg.h
+++ b/Software/bsw/gen/CanIf_Cfg.h
@@ -767,4 +767,53 @@ FULL, this parameter equals 0 for this TxBuffer.*/
 	#define CANIF_BUFFER_SIZE                  (255U)
 #endif
 
+
+/**************************************************************************************************************
+*                                         Sizes of containers muliplicity                                                                  
+*************************************************************************************************************/
+
+/* CAN_DRIVER_NUM is a size of array to define the number of underlying CAN Driver modules*/
+/* It defines muliplicity of CanIfCtrlDrvCfg & CanIfInitHohCfg containers */
+#define  CAN_DRIVER_NUM                             3
+
+/*CAN_TRANSCEIVER_NUM is used to specify the number of containers contains the configuration (parameters)
+of all addressed CAN transceivers by each underlying
+CAN Transceiver Driver module*/
+/*It defines muliplicity of CanIfTrcvDrvCfg & CanIfTrcvCfg containers */
+#define CAN_TRANSCEIVER_NUM                         1
+
+/*BUFFERS_NUM is a size of array to define the number of containers contain the Txbuffer configuration.
+Multiple buffers with different sizes could be configured.
+If CanIfBufferSize (ECUC_CanIf_00834) equals 0, the
+CanIf Tx L-PDU only refers via this CanIfBufferCfg the
+corresponding CanIfHthCfg.*/
+/*It defines muliplicity of CanIfBufferCfg container*/
+#define  BUFFERS_NUM                                10
+
+/* RX_CAN_L-PDU_NUM is a size of array to define the number of containers contain the configuration (parameters)
+of each receive CAN L-PDU.*/
+/*It defines muliplicity of CanIfRxPduCfg container*/
+#define RX_CAN_L-PDU_NUM                            10
+
+/*TX_CAN_L-PDU_NUM is a size of array to define the number of containers contain the configuration (parameters)
+of each transmit CAN L-PDU.*/
+/*It defines muliplicity of CanIfTxPduCfg container*/
+#define TX_CAN_L-PDU_NUM                            10 
+
+/*HRH_OBj_NUM is used to specify the number of containers contains configuration parameters for
+each hardware receive object (HRH).*/
+/*It defines muliplicity of CanIfHrhCfg container*/
+#define HRH_OBj_NUM                                 2
+
+/*HTH_OBj_NUM is used to specify the number of containers contains configuration parameters for
+each hardware transmit object (HTH).*/
+/*It defines muliplicity of CanIfHthCfg container*/
+#define HTH_OBj_NUM                                 2
+
+/*CANID_RANGES_NUM is used to specify the number of containers Defines the parameters required for configurating
+multiple CANID ranges for a given same HRH*/
+/*It defines muliplicity of CanIfHrhRangeCfg container*/
+#define CANID_RANGES_NUM                           16    
+
+
 #endif /* __CANIF_CFG_H__ */

--- a/Software/bsw/gen/CanIf_Cfg.h
+++ b/Software/bsw/gen/CanIf_Cfg.h
@@ -43,14 +43,14 @@
 //  Buffer element length depends on the size of the referencing PDUs
 //  Default Value: false
 //*****************************************************************************
-#define CanIfFixedBuffer                		STD_OFF
+#define CANIF_FIXED_BUFFER                		STD_OFF
 
 //*****************************************************************************
 //  Selects whether Data Length Check is supported.
 //  True: Enabled False: Disabled
 //  Default Value: true
 //*****************************************************************************
-#define CanIfPrivateDataLengthCheck     		STD_ON
+#define CANIF_PRIVATE_DATA_LENGTH_CHECK    		STD_ON
 
 //*****************************************************************************
 //  Selects the desired software filter mechanism for reception only. Each
@@ -64,11 +64,11 @@
 //	parameter CAN_HANDLE_TYPE of the CAN Driver module via
 //	CANIF_HRH_HANDLETYPE_REF for at least one HRH.
 //*****************************************************************************
-typedef uint8 CanIfPrivateSoftwareFilterType;
-#define BINARY	((CanIfPrivateSoftwareFilterType)0x00)
-#define INDEX	((CanIfPrivateSoftwareFilterType)0x01)
-#define LINEAR	((CanIfPrivateSoftwareFilterType)0x02)
-#define TABLE	((CanIfPrivateSoftwareFilterType)0x03)
+typedef uint8 CANIF_PRIVATE_SOFTWARE_FILTER_TYPE;
+#define BINARY									((CANIF_PRIVATE_SOFTWARE_FILTER_TYPE)0x00)
+#define INDEX									((CANIF_PRIVATE_SOFTWARE_FILTER_TYPE)0x01)
+#define LINEAR									((CANIF_PRIVATE_SOFTWARE_FILTER_TYPE)0x02)
+#define TABLE									((CANIF_PRIVATE_SOFTWARE_FILTER_TYPE)0x03)
 
 //*****************************************************************************
 //  Defines whether TTCAN is supported.
@@ -76,7 +76,7 @@ typedef uint8 CanIfPrivateSoftwareFilterType;
 //  normal CAN communication is possible.
 //  Default Value: false
 //*****************************************************************************
-#define CanIfSupportTTCAN                    	STD_OFF
+#define CANIF_SUPPORT_TTCAN                    	STD_OFF
 
 //*****************************************************************************
 //  Switches the development error detection and notification on or off.
@@ -84,26 +84,26 @@ typedef uint8 CanIfPrivateSoftwareFilterType;
 //  false: detection and notification is disabled.
 //  Default Value: false
 //*****************************************************************************
-#define CanIfDevErrorDetect                 	STD_OFF
+#define CANIF_DEV_ERROR_DETECT                 	STD_OFF
 
 //*****************************************************************************
 //  Enable support for dynamic ID handling using L-SDU MetaData.
 //  Default Value: false
 //*****************************************************************************
-#define CanIfMetaDataSupport                	STD_OFF
+#define CANIF_META_DATA_SUPPORT                	STD_OFF
 
 //*****************************************************************************
 //  Configuration parameter to enable/disable dummy API for upper layer
 //  modules which allows to request the cancellation of an I-PDU.
 //*****************************************************************************
-#define CanIfPublicCancelTransmitSupport    	STD_OFF
+#define CANIF_PUBLIC_CANCEL_TRANSMIT_SUPPORT   	STD_OFF
 
 //*****************************************************************************
 //  Defines header files for callback functions which shall be included in
 //	case of CDDs. Range of characters is 1.. 32.
 //	Type: EcucStringParamDef
 //*****************************************************************************
-#define CanIfPublicCddHeaderFile    			32
+#define CANIF_PUBLIC_CDD_HEADER_FILE   			32
 
 //*****************************************************************************
 //	This parameter is used to configure the Can_HwHandleType. The
@@ -111,78 +111,78 @@ typedef uint8 CanIfPrivateSoftwareFilterType;
 //	hardware unit. For CAN hardware units with more than 255 HW objects
 //	the extended range shall be used (UINT16).
 //*****************************************************************************
-typedef uint16 CanIfPublicHandleTypeEnum;
-#define UINT16 	((CanIfPublicHandleTypeEnum)0xFFFF)
-#define UINT8	((CanIfPublicHandleTypeEnum)0x0FF)
+typedef uint16 CANIF_PUBLIC_HANDLE_TYPE_ENUM;
+#define UINT16 									((CANIF_PUBLIC_HANDLE_TYPE_ENUM)0xFFFF)
+#define UINT8									((CANIF_PUBLIC_HANDLE_TYPE_ENUM)0x0FF)
 
 //*****************************************************************************
 //  Selects support of Pretended Network features in CanIf.
 //  True: Enabled False: Disabled
 //  Default Value: false
 //*****************************************************************************
-#define CanIfPublicIcomSupport              	STD_OFF
+#define CANIF_PUBLIC_ICOM_SUPPORT              	STD_OFF
 
 //*****************************************************************************
 //  Selects support for multiple CAN Drivers.
 //  True: Enabled False: Disabled
 //  Default Value: True
 //*****************************************************************************
-#define CanIfPublicMultipleDrvSupport       	STD_ON
+#define CANIF_PUBLIC_MULTIPLE_DRV_SUPPORT      	STD_ON
 
 //*****************************************************************************
 //  Selects support of Partial Network features in CanIf.
 //  True: Enabled False: Disabled
 //  Default Value: False
 //*****************************************************************************
-#define CanIfPublicPnSupport                	STD_OFF
+#define CANIF_PUBLIC_PN_SUPPORT                	STD_OFF
 
 //*****************************************************************************
 //  Enables / Disables the API CanIf_ReadRxPduData() for reading
 //  received L-SDU data.True: Enabled False: Disabled
 //  Default Value: False
 //*****************************************************************************
-#define CanIfPublicReadRxPduDataApi           	STD_OFF
+#define CANIF_PUBLIC_READ_RX_PDU_DATA_API     	STD_OFF
 
 //*****************************************************************************
 //  Enables and disables the API for reading the notification status of
 //  receive L-PDU.True: Enabled False: Disabled
 //  Default Value: False
 //*****************************************************************************
-#define CanIfPublicReadRxPduNotifyStatusApi   	STD_OFF
+#define CANIF_PUBLIC_READ_RX_PDU_NOTIFY_STATUS_API 	STD_OFF
 
 //*****************************************************************************
 //  Enables and disables the API for reading the notification status of
 //  transmit L-PDUs.True: Enabled False: Disabled
 //  Default Value: False
 //*****************************************************************************
-#define CanIfPublicReadTxPduNotifyStatusApi   	STD_OFF
+#define CANIF_PUBLIC_READ_TX_PDU_NOTIFY_STATUS_API 	STD_OFF
 
 //*****************************************************************************
 //  Enables and disables the API for reconfiguration of the CAN Identifier
 //  for each Transmit L-PDU.True: Enabled False: Disabled
 //  Default Value: False
 //*****************************************************************************
-#define CanIfPublicSetDynamicTxIdApi          	STD_OFF
+#define CANIF_PUBLIC_SET_DYNAMIC_TX_ID_API     	STD_OFF
 
 //*****************************************************************************
 //  Enables and disables the buffering of transmit L-PDUs (rejected by the
 //  CanDrv) within the CAN Interface module.True: Enabled False: Disabled
 //  Default Value: False
 //*****************************************************************************
-#define CanIfPublicTxBuffering                	STD_OFF
+#define CANIF_PUBLIC_TX_BUFFERING             	STD_OFF
 
 //*****************************************************************************
 //  Configuration parameter to enable/disable the API to poll for Tx
 //  Confirmation state.
 //	dependency: CAN State Manager module
 //*****************************************************************************
-#define CanIfPublicTxConfirmPollingSupport    	STD_OFF
+#define CANIF_PUBLIC_TX_CONFIRM_POLLING_SUPPORT		STD_OFF
 
 //*****************************************************************************
 //  Selects support for wake up validation. True: Enabled False: Disabled
 //  Default Value: False
 //*****************************************************************************
-#define CanIfPublicWakeupCheckValidSupport		STD_OFF
+#define CANIF_PUBLIC_WAKEUP_CHECK_VALID_SUPPORT		STD_OFF
 
 //*****************************************************************************
 //  If enabled, only NM messages shall validate a detected wake-up event
@@ -193,8 +193,8 @@ typedef uint16 CanIfPublicHandleTypeEnum;
 //	True: Enabled False: Disabled
 //	dependency: CanIfPublicWakeupCheckValidSupport
 //*****************************************************************************
-#if(CanIfPublicWakeupCheckValidSupport==STD_ON)
-	#define CanIfPublicWakeupCheckValidByNM		STD_OFF
+#if(CANIF_PUBLIC_WAKEUP_CHECK_VALID_SUPPORT==STD_ON)
+	#define CANIF_PUBLIC_WAKEUP_CHECK_VALID_BY_NM	STD_OFF
 #endif
 
 //*****************************************************************************
@@ -204,7 +204,7 @@ typedef uint16 CanIfPublicHandleTypeEnum;
 //  is not supported
 //  Default Value: False
 //*****************************************************************************
-#define CanIfSetBaudrateApi                   	STD_OFF
+#define CANIF_SET_BAUDRATE_API                 	STD_OFF
 
 //*****************************************************************************
 //  Enables the CanIf_TriggerTransmit API at Pre-Compile-Time.
@@ -212,14 +212,14 @@ typedef uint16 CanIfPublicHandleTypeEnum;
 //  transmit transmissions. TRUE: Enabled FALSE: Disabled
 //  Default Value: True
 //*****************************************************************************
-#define CanIfTriggerTransmitSupport           	STD_ON
+#define CANIF_TRIGGER_TRANSMIT_SUPPORT         	STD_ON
 
 //*****************************************************************************
 //	Determines wether TxOffLineActive feature (see SWS_CANIF_00072)
 //	is supported by CanIf. True: Enabled False: Disabled
 //	Default value: False
 //*****************************************************************************
-#define CanIfTxOfflineActiveSupport			  	STD_OFF
+#define CANIF_TX_OFFLINE_ACTIVE_SUPPORT		  	STD_OFF
 
 //*****************************************************************************
 //	Enables and disables the API for reading the version information about
@@ -227,7 +227,7 @@ typedef uint16 CanIfPublicHandleTypeEnum;
 //	True: Enabled False: Disabled
 //	Default value: False
 //*****************************************************************************
-#define CanIfVersionInfoApi					  	STD_OFF
+#define CANIF_VERSION_INFO_API				  	STD_OFF
 
 //*****************************************************************************
 //	Enables the CanIf_CheckWakeup API at Pre-Compile-Time.
@@ -235,7 +235,7 @@ typedef uint16 CanIfPublicHandleTypeEnum;
 //	True: Enabled False: Disabled
 //	Default value: True
 //*****************************************************************************
-#define CanIfWakeupSupport						STD_ON
+#define CANIF_WAKEUP_SUPPORT					STD_ON
 
 //*****************************************************************************
 //	Selects the CAN Interface specific configuration setup. This type of the
@@ -245,38 +245,38 @@ typedef uint16 CanIfPublicHandleTypeEnum;
 //	Type: EcucStringParamDef
 //  Length: 1 - 32
 //*****************************************************************************
-#define CanIfInitCfgSet							(32U)
+#define CANIF_INIT_CFG_SET						(32U)
 
 /* Maximum total size of all Tx buffers. This parameter is needed only in
 case of post-build loadable implementation using static memory
 allocation.
 Range: 0..18446744073709551615 */
-#define CanIfMaxBufferSizeValue					(18446744073709551615)
+#define CANIF_MAX_BUFFER_SIZE					(18446744073709551615)
 
 /* Maximum number of Pdus. This parameter is needed only in case of
 post-build loadable implementation using static memory allocation.
 Range: 0..18446744073709551615 */
-#define CanIfMaxRxPduCfgValue					(18446744073709551615)
+#define CANIF_MAX_RX_PDU_CFG					(18446744073709551615)
 
 /* Maximum number of Pdus. This parameter is needed only in case of
 post-build loadable implementation using static memory allocation.
 Range: 0..18446744073709551615 */
-#define CanIfMaxTxPduCfgValue					(18446744073709551615)
+#define CANIF_MAX_TX_PDU_CFG					(18446744073709551615)
 
 /* CAN Identifier of transmit CAN L-PDUs used by the CAN Driver for
 CAN L-PDU transmission. Range: 11 Bit For Standard CAN Identifier
 ... 29 Bit For Extended CAN identifier
 The CAN Identifier may be omitted for dynamic transmit L-PDUs. */
-#define CanIfTxPduCanId0						(0U)
-#define CanIfTxPduCanId1						(1U)
+#define CANIF_TX_PDU_CAN_ID0					(0U)
+#define CANIF_TX_PDU_CAN_ID1					(1U)
 
 /* Identifier mask which denotes relevant bits in the CAN Identifier. This
 parameter may be used to keep parts of the CAN Identifier of dynamic
 transmit L-PDUs static. Range: 11 bits for Standard CAN Identifier, 29
 bits for Extended CAN Identifier.
 Range: 0 .. 536870911 */
-#define CanIfTxPduCanIdMask0					(1<<(uint32)0)
-#define CanIfTxPduCanIdMask1					(1<<(uint32)1)
+#define CANIF_TX_PDU_CAN_ID_MASK0				(1<<(uint32)0)
+#define CANIF_TX_PDU_CAN_ID_MASK1				(1<<(uint32)1)
 
 /* Type of CAN Identifier of the transmit CAN L-PDU used by the CAN
 Driver module for CAN L-PDU transmission. 
@@ -284,47 +284,47 @@ Range: 	EXTENDED_CAN CAN 		frame with extended identifier (29 bits)
 		EXTENDED_FD_CAN CAN FD 	frame with extended identifier (29 bits)
 		STANDARD_CAN CAN 		frame with standard identifier (11 bits)
 		STANDARD_FD_CAN CAN FD 	frame with standard identifier (11 bits)*/
-typedef uint8 CANIF_TXPDU_CANID_TYPE;
-#define EXTENDED_CAN							((CANIF_TXPDU_CANID_TYPE)0x00U)
-#define EXTENDED_FD_CAN							((CANIF_TXPDU_CANID_TYPE)0x01U)
-#define STANDARD_CAN							((CANIF_TXPDU_CANID_TYPE)0x02U)
-#define STANDARD_FD_CAN							((CANIF_TXPDU_CANID_TYPE)0x03U)
+typedef uint8 CANIF_TX_PDU_CAN_ID_TYPE;
+#define EXTENDED_CAN							((CANIF_TX_PDU_CAN_ID_TYPE)0x00U)
+#define EXTENDED_FD_CAN							((CANIF_TX_PDU_CAN_ID_TYPE)0x01U)
+#define STANDARD_CAN							((CANIF_TX_PDU_CAN_ID_TYPE)0x02U)
+#define STANDARD_FD_CAN							((CANIF_TX_PDU_CAN_ID_TYPE)0x03U)
 
 /* ECU wide unique, symbolic handle for transmit CAN L-SDU.
 Range: 0..max. number of CantTxPduIds. Range: 0 - 4294967295*/
-#define CanIfTxPduIdValue						(4294967295U)
+#define CANIF_TX_PDU_ID							(4294967295U)
 
 /* If CanIfPublicPnFilterSupport is enabled, by this parameter PDUs
 could be configured which will pass the CanIfPnFilter.
 If there is no CanIfTxPduPnFilterPdu configured per controller,
 the corresponding controller applies no CanIfPnFilter.
 dependency: This parameter shall only be configurable if CanIfPublicPnSupport equals True. */
-#if(CanIfPublicPnSupport==STD_ON)
-	#define CANIF_TXPDU_PNFILTER_PDU			STD_OFF
+#if(CANIF_PUBLIC_PN_SUPPORT==STD_ON)
+	#define CANIF_TX_PDU_PN_FILTER_PDU			STD_OFF
 #endif
 
 /* Enables and disables transmit confirmation for each transmit CAN
 L-SDU for reading its notification status.
 True: Enabled False: Disabled
 dependency: CANIF_READTXPDU_NOTIFY_STATUS_API must be enabled.*/
-#if(CanIfPublicReadTxPduNotifyStatusApi==STD_ON)
-	#define CANIF_TXPDU_READ_NOTIFYSTATUS		STD_OFF
+#if(CANIF_PUBLIC_READ_TX_PDU_NOTIFY_STATUS_API==STD_ON)
+	#define CANIF_TX_PDU_READ_NOTIFY_STATUS		STD_OFF
 #endif
 
 /* Determines if or if not CanIf shall use the trigger transmit API for this PDU.
 dependency: If CanIfTxPduTriggerTransmit is TRUE then CanIfTxPduUserTxConfirmationUL 
 has to be either PDUR or CDD and CanIfTxPduUserTriggerTransmitName has to be specified accordingly */
-#define CANIF_TXPDU_TRIGGERTRANSMIT				STD_OFF
+#define CANIF_TX_PDU_TRIGGER_TRANSMIT			STD_OFF
 
 /* Enables/disables truncation of PDUs that exceed the configured size. */
-#define CANIF_TXPDU_TRUNCATION					STD_ON
+#define CANIF_TX_PDU_TRUNCATION					STD_ON
 
 /* Defines the type of each transmit CAN L-PDU.
 Range:	DYNAMIC 	CAN ID is defined at runtime.
 		STATIC 		CAN ID is defined at compile-time. */
-typedef uint8 CANIF_TXPDU_TYPE;
-#define DYNAMIC									((CANIF_TXPDU_TYPE)0x00U)
-#define STATIC									((CANIF_TXPDU_TYPE)0x01U)
+typedef uint8 CANIF_TX_PDU_TYPE;
+#define DYNAMIC									((CANIF_TX_PDU_TYPE)0x00U)
+#define STATIC									((CANIF_TX_PDU_TYPE)0x01U)
 
 /* This parameter defines the upper layer (UL) module to which the confirmation of
 the successfully transmitted CANTXPDUID has to be routed via the <User_TxConfirmation>.
@@ -344,16 +344,52 @@ Note: If CanIfTxPduTriggerTransmit is not specified or FALSE, no upper
 layer modules have to be configured for Trigger Transmit. Therefore,
 <User_TriggerTransmit>() will not be called and CanIfTxPduUserTxConfirmationUL
 as well as CanIfTxPduUserTriggerTransmitName need not to be configured. */
-#if(CANIF_TXPDU_TRIGGERTRANSMIT==STD_ON)
-	typedef uint8 CANIF_TXPDU_USERTXCONFIRMATION_UL;
-	#define CAN_NM								((CANIF_TXPDU_USERTXCONFIRMATION_UL)0x00U)
-	#define CAN_TP								((CANIF_TXPDU_USERTXCONFIRMATION_UL)0x01U)
-	#define CAN_TSYN							((CANIF_TXPDU_USERTXCONFIRMATION_UL)0x02U)
-	#define CDD									((CANIF_TXPDU_USERTXCONFIRMATION_UL)0x03U)
-	#define J1939NM								((CANIF_TXPDU_USERTXCONFIRMATION_UL)0x04U)
-	#define J1939TP								((CANIF_TXPDU_USERTXCONFIRMATION_UL)0x05U)
-	#define PDUR								((CANIF_TXPDU_USERTXCONFIRMATION_UL)0x06U)
-	#define XCP									((CANIF_TXPDU_USERTXCONFIRMATION_UL)0x07U)
+#if(CANIF_TX_PDU_TRIGGER_TRANSMIT==STD_ON)
+	typedef uint8 CANIF_TX_PDU_USER_TX_CONFIRMATION_UL;
+	#define CAN_NM								((CANIF_TX_PDU_USER_TX_CONFIRMATION_UL)0x00U)
+	#define CAN_TP								((CANIF_TX_PDU_USER_TX_CONFIRMATION_UL)0x01U)
+	#define CAN_TSYN							((CANIF_TX_PDU_USER_TX_CONFIRMATION_UL)0x02U)
+	#define CDD									((CANIF_TX_PDU_USER_TX_CONFIRMATION_UL)0x03U)
+	#define J1939NM								((CANIF_TX_PDU_USER_TX_CONFIRMATION_UL)0x04U)
+	#define J1939TP								((CANIF_TX_PDU_USER_TX_CONFIRMATION_UL)0x05U)
+	#define PDUR								((CANIF_TX_PDU_USER_TX_CONFIRMATION_UL)0x06U)
+	#define XCP									((CANIF_TX_PDU_USER_TX_CONFIRMATION_UL)0x07U)
+#endif
+
+/* This parameter defines the name of the <User_TriggerTransmit>. This parameter depends on the parameter
+CanIfTxPduUserTxConfirmationUL. If CanIfTxPduUserTxConfirmationUL equals CAN_TP, CAN_NM, PDUR,
+XCP, CAN_TSYN, J1939NM or J1939TP, the name of the <User_TriggerTransmit> is fixed. If CanIfTxPduUserTxConfirmationUL
+equals CDD, the name of the <User_TxConfirmation> is selectable. Please be aware that this parameter depends on the same
+parameter as CanIfTxPduUserTxConfirmationName. It shall be clear which upper layer is responsible for that PDU.
+dependency: CanIfTxPduUserTriggerTransmitName requires CanIfTxPduUserTxConfirmationUL to be either PDUR or CDD.
+
+Note: If CanIfTxPduTriggerTransmit is not specified or FALSE, no upper layer modules have to be configured for
+Trigger Transmit. Therefore, <User_TriggerTransmit>() will not be called and CanIfTxPduUserTxConfirmationUL
+as well as CanIfTxPduUserTriggerTransmitName need not to be configured.
+
+[SWS_CANIF_00890] Configuration of <User_TriggerTransmit>(): If CanIfTxPduUserTxConfirmationUL is set to PDUR,
+CanIfTxPduUserTrigger- TransmitName must be PduR_CanIfTriggerTransmit.
+
+[SWS_CANIF_00891] Configuration of <User_TriggerTransmit>(): If CanIfTxPduUserTxConfirmationUL is set to CDD,
+the name of the API <User_TriggerTransmit>() has to be configured via parameter CanIfTxPdu- UserTriggerTransmitName. */
+#if(CANIF_TX_PDU_TRIGGER_TRANSMIT==STD_ON)
+	#if(CanIfTxPduUserTxConfirmationUL==PDUR)
+		#define CANIF_TX_PDU_USER_TRIGGER_TRANSMIT_NAME	PduR_CanIfTriggerTransmit
+	#else if(CanIfTxPduUserTxConfirmationUL==CAN_NM)
+		#define CANIF_TX_PDU_USER_TRIGGER_TRANSMIT_NAME	CanNm_CanIfTriggerTransmit
+	#else if(CanIfTxPduUserTxConfirmationUL==J1939NM)
+		#define CANIF_TX_PDU_USER_TRIGGER_TRANSMIT_NAME	J1939Nm_CanIfTriggerTransmit
+	#else if(CanIfTxPduUserTxConfirmationUL==J1939TP)
+		#define CANIF_TX_PDU_USER_TRIGGER_TRANSMIT_NAME	J1939Tp_CanIfTriggerTransmit
+	#else if(CanIfTxPduUserTxConfirmationUL==CAN_TP)
+		#define CANIF_TX_PDU_USER_TRIGGER_TRANSMIT_NAME	CanTp_CanIfTriggerTransmit
+	#else if(CanIfTxPduUserTxConfirmationUL==XCP)
+		#define CANIF_TX_PDU_USER_TRIGGER_TRANSMIT_NAME	Xcp_CanIfTriggerTransmit
+	#else if(CanIfTxPduUserTxConfirmationUL==CAN_TSYN)
+		#define CANIF_TX_PDU_USER_TRIGGER_TRANSMIT_NAME	CanTSyn_CanIfTriggerTransmit
+	#else if(CanIfTxPduUserTxConfirmationUL==CDD)
+		#define CANIF_TX_PDU_USER_TRIGGER_TRANSMIT_NAME	Cdd_CanIfTriggerTransmit /* Selectable */
+	#endif	
 #endif
 
 /* This parameter defines the name of the <User_TxConfirmation>. This parameter depends
@@ -370,24 +406,23 @@ is set to PDUR, CanIfTxPduUserTriggerTransmitName must be PduR_CanIfTriggerTrans
 
 [SWS_CANIF_00891] Configuration of <User_TriggerTransmit>(): If CanIfTxPduUserTxConfirmationUL
 is set to CDD, the name of the API <User_TriggerTransmit>() has to be configured via parameter CanIfTxPduUserTriggerTransmitName. */
-#if(CANIF_TXPDU_TRIGGERTRANSMIT==STD_ON)
+#if(CANIF_TX_PDU_TRIGGER_TRANSMIT==STD_ON)
 	#if(CanIfTxPduUserTxConfirmationUL==PDUR)
-		#define CanIfTxPduUserTxConfirmationName	PduR_CanIfTxConfirmation
+		#define CANIF_TX_PDU_USER_TX_CONFIRMATION_NAME	PduR_CanIfTxConfirmation
 	#else if(CanIfTxPduUserTxConfirmationUL==CAN_NM)
-		#define CanIfTxPduUserTxConfirmationName	CanNm_TxConfirmation
+		#define CANIF_TX_PDU_USER_TX_CONFIRMATION_NAME	CanNm_TxConfirmation
 	#else if(CanIfTxPduUserTxConfirmationUL==J1939NM)
-		#define CanIfTxPduUserTxConfirmationName	J1939Nm_TxConfirmation
+		#define CANIF_TX_PDU_USER_TX_CONFIRMATION_NAME	J1939Nm_TxConfirmation
 	#else if(CanIfTxPduUserTxConfirmationUL==J1939TP)
-		#define CanIfTxPduUserTxConfirmationName	J1939Tp_TxConfirmation
+		#define CANIF_TX_PDU_USER_TX_CONFIRMATION_NAME	J1939Tp_TxConfirmation
 	#else if(CanIfTxPduUserTxConfirmationUL==CAN_TP)
-		#define CanIfTxPduUserTxConfirmationName	CanTp_TxConfirmation
+		#define CANIF_TX_PDU_USER_TX_CONFIRMATION_NAME	CanTp_TxConfirmation
 	#else if(CanIfTxPduUserTxConfirmationUL==XCP)
-		#define CanIfTxPduUserTxConfirmationName	Xcp_CanIfTxConfirmation
+		#define CANIF_TX_PDU_USER_TX_CONFIRMATION_NAME	Xcp_CanIfTxConfirmation
 	#else if(CanIfTxPduUserTxConfirmationUL==CAN_TSYN)
-		#define CanIfTxPduUserTxConfirmationName	CanTSyn_CanIfTxConfirmation
-
+		#define CANIF_TX_PDU_USER_TX_CONFIRMATION_NAME	CanTSyn_CanIfTxConfirmation
 	#else if(CanIfTxPduUserTxConfirmationUL==CDD)
-		#define CanIfTxPduUserTxConfirmationName	CDD_CanIfTxConfirmation /* Selectable */
+		#define CANIF_TX_PDU_USER_TX_CONFIRMATION_NAME	Cdd_CanIfTxConfirmation /* Selectable */
 	#endif	
 #endif
 
@@ -397,16 +432,16 @@ Exa: Software Filtering. This parameter is used if exactly one Can
 Identifier is assigned to the Pdu. If a range is assigned then the
 CanIfRxPduCanIdRange parameter shall be used.
 Range: 11 Bit For Standard CAN Identifier ... 29 Bit For Extended CAN identifier */
-#define CanIfRxPduCanId0						(0U)
-#define CanIfRxPduCanId1						(1U)
+#define CANIF_RX_PDU_CAN_ID0					(0U)
+#define CANIF_RX_PDU_CAN_ID1					(1U)
 
 /* Identifier mask which denotes relevant bits in the CAN Identifier. This
 parameter defines a CAN Identifier range in an alternative way to
 CanIfRxPduCanIdRange. It identifies the bits of the configured CAN
 Identifier that must match the received CAN Identifier. Range: 11 bits
 for Standard CAN Identifier, 29 bits for Extended CAN Identifier. */
-#define CanIfRxPduCanIdMask0					(1<<(uint32)0)
-#define CanIfRxPduCanIdMask1					(1<<(uint32)1)
+#define CANIF_RX_PDU_CAN_ID_MASK0				(1<<(uint32)0)
+#define CANIF_RX_PDU_CAN_ID_MASK1				(1<<(uint32)1)
 
 /* CAN Identifier of receive CAN L-PDUs used by the CAN Driver for
 CAN L-PDU reception.
@@ -417,46 +452,46 @@ Range: 	EXTENDED_CAN 			CAN 2.0 or CAN FD frame with extended identifier (29 bit
 		STANDARD_FD_CAN 		CAN FD frame with standard identifier (11 bits)
 		STANDARD_NO_FD_CAN 		CAN 2.0 frame with standard identifier (11 bits)
 dependency: If CanIfRxPduDataLength > 8 then CanIfRxPduCanIdType must not be STANDARD_NO_FD_CAN or EXTENDED_NO_FD_CAN */
-typedef uint8 CANIF_RXPDU_CANID_TYPE;
-#define EXTENDED_CAN							((CANIF_RXPDU_CANID_TYPE)0x00U)
-#define EXTENDED_FD_CAN							((CANIF_RXPDU_CANID_TYPE)0x01U)
+typedef uint8 CANIF_RX_PDU_CAN_ID_TYPE;
+#define EXTENDED_CAN							((CANIF_RX_PDU_CAN_ID_TYPE)0x00U)
+#define EXTENDED_FD_CAN							((CANIF_RX_PDU_CAN_ID_TYPE)0x01U)
 #if(CanIfRxPduDataLength <= 8)
-	#define EXTENDED_NO_FD_CAN					((CANIF_RXPDU_CANID_TYPE)0x02U)
+	#define EXTENDED_NO_FD_CAN					((CANIF_RX_PDU_CAN_ID_TYPE)0x02U)
 #endif
-#define STANDARD_CAN							((CANIF_RXPDU_CANID_TYPE)0x03U)
-#define STANDARD_FD_CAN							((CANIF_RXPDU_CANID_TYPE)0x04U)
+#define STANDARD_CAN							((CANIF_RX_PDU_CAN_ID_TYPE)0x03U)
+#define STANDARD_FD_CAN							((CANIF_RX_PDU_CAN_ID_TYPE)0x04U)
 #if(CanIfRxPduDataLength <= 8)
-	#define STANDARD_NO_FD_CAN					((CANIF_RXPDU_CANID_TYPE)0x05U)
+	#define STANDARD_NO_FD_CAN					((CANIF_RX_PDU_CAN_ID_TYPE)0x05U)
 #endif
 
 /* Data length of the received CAN L-PDUs used by the CAN Interface. This information is
 used for Data Length Check. Additionally it might specify the valid bits in case of the 
 discrete DLC for CAN FD L-PDUs > 8 bytes. The data area size of a CAN L-PDU can have a range from 0 to 64 bytes. */
-#define CANIF_RXPDU_DATALENGTH					(8U)
+#define CANIF_RX_PDU_DATA_LENGTH				(8U)
 
 /* ECU wide unique, symbolic handle for receive CAN L-SDU. It shall
 fulfill ANSI/AUTOSAR definitions for constant defines. Range: 0..max. number of defined CanRxPduIds
 Range: 0 - 4294967295 */
-#define CanIfRxPduIdValue						(4294967295U)
+#define CANIF_RX_PDU_ID							(4294967295U)
 
 /* Enables and disables the Rx buffering for reading of received L-SDU
 data. True: Enabled False: Disabled
 dependency: CANIF_CANPDUID_READDATA_API must be enabled */
-#define CANIF_CANPDUID_READDATA_API				(STD_ON)
+#define CANIF_CAN_PDU_ID_READ_DATA_API			(STD_ON)
 
 /* Enables and disables the Rx buffering for reading of received L-SDU
 data. True: Enabled False: Disabled
 dependency: CANIF_CANPDUID_READDATA_API must be enabled */
-#if(CANIF_CANPDUID_READDATA_API==STD_ON)
-	#define CANIF_RXPDU_READDATA				(STD_OFF)
+#if(CANIF_CAN_PDU_ID_READ_DATA_API==STD_ON)
+	#define CANIF_RX_PDU_READ_DATA				(STD_OFF)
 #endif
 
 /* Enables and disables receive indication for each receive CAN L-SDU
 for reading its notification status.
 True: Enabled False: Disabled
 dependency: CANIF_READRXPDU_NOTIFY_STATUS_API must be enabled. */
-#if(CanIfPublicReadRxPduNotifyStatusApi==STD_ON)
-	#define CANIF_RXPDU_READ_NOTIFYSTATUS		(STD_OFF)
+#if(CANIF_PUBLIC_READ_RX_PDU_NOTIFY_STATUS_API==STD_ON)
+	#define CANIF_RX_PDU_READ_NOTIFY_STATUS		(STD_OFF)
 #endif
 
 /* This parameter defines the upper layer (UL) module to which the indication of
@@ -477,15 +512,15 @@ Note: If receive indications are not necessary or no upper layer modules
 are configured for receive indications and thus <User_RxIndication>()
 shall not be called, CANIF_RXPDU_USERRXINDICATION_UL and
 CANIF_RXPDU_USERRXINDICATION_NAME need not to be configured. */
-typedef uint8 CANIF_RXPDU_USERRXINDICATION_UL;
-#define CAN_NM									((CANIF_RXPDU_USERRXINDICATION_UL)0x00U)
-#define CAN_TP									((CANIF_RXPDU_USERRXINDICATION_UL)0x01U)
-#define CAN_TSYN								((CANIF_RXPDU_USERRXINDICATION_UL)0x02U)
-#define CDD										((CANIF_RXPDU_USERRXINDICATION_UL)0x03U)
-#define J1939NM									((CANIF_RXPDU_USERRXINDICATION_UL)0x04U)
-#define J1939TP									((CANIF_RXPDU_USERRXINDICATION_UL)0x05U)
-#define PDUR									((CANIF_RXPDU_USERRXINDICATION_UL)0x06U)
-#define XCP										((CANIF_RXPDU_USERRXINDICATION_UL)0x07U)
+typedef uint8 CANIF_RX_PDU_USER_RX_INDICATION_UL;
+#define CAN_NM									((CANIF_RX_PDU_USER_RX_INDICATION_UL)0x00U)
+#define CAN_TP									((CANIF_RX_PDU_USER_RX_INDICATION_UL)0x01U)
+#define CAN_TSYN								((CANIF_RX_PDU_USER_RX_INDICATION_UL)0x02U)
+#define CDD										((CANIF_RX_PDU_USER_RX_INDICATION_UL)0x03U)
+#define J1939NM									((CANIF_RX_PDU_USER_RX_INDICATION_UL)0x04U)
+#define J1939TP									((CANIF_RX_PDU_USER_RX_INDICATION_UL)0x05U)
+#define PDUR									((CANIF_RX_PDU_USER_RX_INDICATION_UL)0x06U)
+#define XCP										((CANIF_RX_PDU_USER_RX_INDICATION_UL)0x07U)
 
 /* This parameter defines the name of the <User_RxIndication>. This parameter depends
 on the parameter CanIfRxPduUserRxIndicationUL. If CanIfRxPduUserRxIndicationUL equals
@@ -496,41 +531,40 @@ Note: If receive indications are not necessary or no upper layer modules are con
 for receive indications and thus <User_RxIndication>() shall not be called, CANIF_RXPDU_USERRXINDICATION_UL
 and CANIF_RXPDU_USERRXINDICATION_NAME need not to be configured. */
 #if(CanIfRxPduUserRxIndicationUL==PDUR)
-	#define CanIfRxPduUserRxIndicationName		PduR_CanIfRxIndication
+	#define CANIF_RX_PDU_USER_RX_INDICATION_NAME	PduR_CanIfRxIndication
 #else if(CanIfRxPduUserRxIndicationUL==CAN_NM)
-	#define CanIfRxPduUserRxIndicationName		CanNm_RxIndication
+	#define CANIF_RX_PDU_USER_RX_INDICATION_NAME	CanNm_RxIndication
 #else if(CanIfRxPduUserRxIndicationUL==J1939NM)
-	#define CanIfRxPduUserRxIndicationName		J1939Nm_RxIndication
+	#define CANIF_RX_PDU_USER_RX_INDICATION_NAME	J1939Nm_RxIndication
 #else if(CanIfRxPduUserRxIndicationUL==J1939TP)
-	#define CanIfRxPduUserRxIndicationName		J1939Tp_RxIndication
+	#define CANIF_RX_PDU_USER_RX_INDICATION_NAME	J1939Tp_RxIndication
 #else if(CanIfRxPduUserRxIndicationUL==CAN_TP)
-	#define CanIfRxPduUserRxIndicationName		CanTp_RxIndication
+	#define CANIF_RX_PDU_USER_RX_INDICATION_NAME	CanTp_RxIndication
 #else if(CanIfRxPduUserRxIndicationUL==XCP)
-	#define CanIfRxPduUserRxIndicationName		Xcp_CanIfRxIndication
+	#define CANIF_RX_PDU_USER_RX_INDICATION_NAME	Xcp_CanIfRxIndication
 #else if(CanIfRxPduUserRxIndicationUL==CAN_TSYN)
-	#define CanIfRxPduUserRxIndicationName		CanTSyn_CanIfRxIndication
-
+	#define CANIF_RX_PDU_USER_RX_INDICATION_NAME	CanTSyn_CanIfRxIndication
 #else if(CanIfRxPduUserRxIndicationUL==CDD)
-	#define CanIfRxPduUserRxIndicationName		Cdd_CanIfRxIndication /* Selectable */
+	#define CANIF_RX_PDU_USER_RX_INDICATION_NAME	Cdd_CanIfRxIndication /* Selectable */
 #endif	
 
 /* Lower CAN Identifier of a receive CAN L-PDU for identifier range
 definition, in which all CAN Ids are mapped to one PduId.
 Range: 0 - 536870911 */
-#define CANIF_RXPDU_CANIDRANGE_LOWERCANID 		(0U)
+#define CANIF_RX_PDU_CAN_ID_RANGE_LOWER_CAN_ID 		(0U)
 
 /* Upper CAN Identifier of a receive CAN L-PDU for identifier range
 definition, in which all CAN Ids are mapped to one PduId.
 Range: 0 - 536870911 */
-#define CANIF_RXPDU_CANIDRANGE_UPPERCANID		(536870911U)
+#define CANIF_RX_PDU_CAN_ID_RANGE_UPPER_CAN_ID		(536870911U)
 
 /* This parameter defines the upper layer module to which the CheckTrcvWakeFlagIndication
 from the Driver modules have to be routed. If CANIF_PUBLIC_PN_SUPPORT equals False, this
 parameter shall not be configurable. dependency: CANIF_PUBLIC_PN_SUPPORT */
-#if(CanIfPublicPnSupport==STD_ON)
-	typedef uint8 CANIF_DISPATCH_USERCHECKTRCVWAKEFLAGINDICATION_UL;
-	#define CAN_SM								((CANIF_DISPATCH_USERCHECKTRCVWAKEFLAGINDICATION_UL)0x00)
-	#define CDD									((CANIF_DISPATCH_USERCHECKTRCVWAKEFLAGINDICATION_UL)0x01)
+#if(CANIF_PUBLIC_PN_SUPPORT==STD_ON)
+	typedef uint8 CANIF_DISPATCH_USER_CHECK_TRCV_WAKE_FLAG_INDICATION_UL;
+	#define CAN_SM								((CANIF_DISPATCH_USER_CHECK_TRCV_WAKE_FLAG_INDICATION_UL)0x00)
+	#define CDD									((CANIF_DISPATCH_USER_CHECK_TRCV_WAKE_FLAG_INDICATION_UL)0x01)
 #endif
 
 /* This parameter defines the name of <User_CheckTrcvWakeFlagIndication>. If
@@ -538,108 +572,108 @@ CanIfDispatchUserCheckTrcvWakeFlagIndicationUL equals CAN_SM the name of
 <User_CheckTrcvWakeFlagIndication> is fixed. If it equals CDD, the name is selectable.
 If CanIfPublicPnSupport equals False, this parameter shall not be configurable.
 dependency: CANIF_DISPATCH_USERCHECKTRCVWAKEFLAGINDICATION_UL, CANIF_PUBLIC_PN_SUPPORT */
-#if(CanIfPublicPnSupport==STD_ON)
-	#if(CanIfDispatchUserCheckTrcvWakeFlagIndicationUL==CAN_SM)
-		#define CanIfDispatchUserCheckTrcvWakeFlagIndicationName	CanSM_CheckTrcvWakeFlagIndication
-	#else if(CanIfDispatchUserCheckTrcvWakeFlagIndicationUL==CDD)
-		#define CanIfDispatchUserCheckTrcvWakeFlagIndicationName	Cdd_CheckTrcvWakeFlagIndication
+#if(CANIF_PUBLIC_PN_SUPPORT==STD_ON)
+	#if(CANIF_DISPATCH_USER_CHECK_TRCV_WAKE_FLAG_INDICATION_UL==CAN_SM)
+		#define CANIF_DISPATCH_USER_CHECK_TRCV_WAKE_FLAG_INDICATION_NAME 	CanSM_CheckTrcvWakeFlagIndication
+	#else if(CANIF_DISPATCH_USER_CHECK_TRCV_WAKE_FLAG_INDICATION_UL==CDD)
+		#define CANIF_DISPATCH_USER_CHECK_TRCV_WAKE_FLAG_INDICATION_NAME	Cdd_CheckTrcvWakeFlagIndication
 	#endif
 #endif
 
 /* This parameter defines the upper layer module to which the ClearTrcvWufFlagIndication
 from the Driver modules have to be routed. If CANIF_PUBLIC_PN_SUPPORT equals False, this
 parameter shall not be configurable. dependency: CANIF_PUBLIC_PN_SUPPORT */
-#if(CanIfPublicPnSupport==STD_ON)
-	typedef uint8 CANIF_DISPATCH_USERCLEARTRCVWUFFLAGINDICATION_UL;
-	#define CAN_SM								((CANIF_DISPATCH_USERCLEARTRCVWUFFLAGINDICATION_UL)0x00)
-	#define CDD									((CANIF_DISPATCH_USERCLEARTRCVWUFFLAGINDICATION_UL)0x01)
+#if(CANIF_PUBLIC_PN_SUPPORT==STD_ON)
+	typedef uint8 CANIF_DISPATCH_USER_CLEAR_TRCV_WUF_FLAG_INDICATION_UL;
+	#define CAN_SM								((CANIF_DISPATCH_USER_CLEAR_TRCV_WUF_FLAG_INDICATION_UL)0x00)
+	#define CDD									((CANIF_DISPATCH_USER_CLEAR_TRCV_WUF_FLAG_INDICATION_UL)0x01)
 #endif
 
 /* This parameter defines the name of <User_ClearTrcvWufFlagIndication>. If
 CanIfDispatchUserClearTrcvWufFlagIndicationUL equals CAN_SM the name of
 <User_ClearTrcvWufFlagIndication> is fixed. If it equals CDD, the name is selectable.
 If CANIF_PUBLIC_PN_SUPPORT equals False, this parameter shall not be configurable. */
-#if(CanIfPublicPnSupport==STD_ON)
-	#if(CanIfDispatchUserClearTrcvWufFlagIndicationUL==CAN_SM)
-		#define CanIfDispatchUserClearTrcvWufFlagIndicationName		CanSM_ClearTrcvWufFlagIndication
-	#else if(CanIfDispatchUserClearTrcvWufFlagIndicationUL==CDD)
-		#define CanIfDispatchUserClearTrcvWufFlagIndicationName		Cdd_ClearTrcvWufFlagIndication
+#if(CANIF_PUBLIC_PN_SUPPORT==STD_ON)
+	#if(CANIF_DISPATCH_USER_CLEAR_TRCV_WUF_FLAG_INDICATION_UL==CAN_SM)
+		#define CANIF_DISPATCH_USER_CLEAR_TRCV_WUF_FLAG_INDICATION_NAME		CanSM_ClearTrcvWufFlagIndication
+	#else if(CANIF_DISPATCH_USER_CLEAR_TRCV_WUF_FLAG_INDICATION_UL==CDD)
+		#define CANIF_DISPATCH_USER_CLEAR_TRCV_WUF_FLAG_INDICATION_NAME		Cdd_ClearTrcvWufFlagIndication
 	#endif
 #endif
 
 /* This parameter defines the upper layer module to which the ConfirmPnAvailability notification
 from the Driver modules have to be routed. If CANIF_PUBLIC_PN_SUPPORT equals False, this
 parameter shall not be configurable. dependency: CANIF_PUBLIC_PN_SUPPORT */
-#if(CanIfPublicPnSupport==STD_ON)
-	typedef uint8 CANIF_DISPATCH_USERCONFIRMPNAVAILABILITY_UL;
-	#define CAN_SM								((CANIF_DISPATCH_USERCONFIRMPNAVAILABILITY_UL)0x00)
-	#define CDD									((CANIF_DISPATCH_USERCONFIRMPNAVAILABILITY_UL)0x01)
+#if(CANIF_PUBLIC_PN_SUPPORT==STD_ON)
+	typedef uint8 CANIF_DISPATCH_USER_CONFIRM_PN_AVAILABILITY_UL;
+	#define CAN_SM								((CANIF_DISPATCH_USER_CONFIRM_PN_AVAILABILITY_UL)0x00)
+	#define CDD									((CANIF_DISPATCH_USER_CONFIRM_PN_AVAILABILITY_UL)0x01)
 #endif
 
 /* This parameter defines the name of <User_ConfirmPnAvailability>. If
 CanIfDispatchUserConfirmPnAvailabilityUL equals CAN_SM the name of
 <User_ConfirmPnAvailability> is fixed. If it equals CDD, the name is selectable.
 If CANIF_PUBLIC_PN_SUPPORT equals False, this parameter shall not be configurable. */
-#if(CanIfPublicPnSupport==STD_ON)
-	#if(CanIfDispatchUserConfirmPnAvailabilityUL==CAN_SM)
-		#define CanIfDispatchUserConfirmPnAvailabilityName		CanSM_ConfirmPnAvailability
-	#else if(CanIfDispatchUserConfirmPnAvailabilityUL==CDD)
-		#define CanIfDispatchUserConfirmPnAvailabilityName		Cdd_ConfirmPnAvailability
+#if(CANIF_PUBLIC_PN_SUPPORT==STD_ON)
+	#if(CANIF_DISPATCH_USER_CONFIRM_PN_AVAILABILITY_UL==CAN_SM)
+		#define CANIF_DISPATCH_USER_CONFIRM_PN_AVAILABILITY_NAME		CanSM_ConfirmPnAvailability
+	#else if(CANIF_DISPATCH_USER_CONFIRM_PN_AVAILABILITY_UL==CDD)
+		#define CANIF_DISPATCH_USER_CONFIRM_PN_AVAILABILITY_NAME		Cdd_ConfirmPnAvailability
 	#endif
 #endif
 
 /* This parameter defines the upper layer (UL) module to which the notifications of all
 ControllerBusOff events from the CAN Driver modules have to be routed via <User_ControllerBusOff>.
 There is no possibility to configure no upper layer (UL) module as the provider of <User_ControllerBusOff>. */
-typedef uint8 CANIF_DISPATCH_USERCTRLBUSOFF_UL;
-#define CAN_SM									((CANIF_DISPATCH_USERCTRLBUSOFF_UL)0x00)
-#define CDD										((CANIF_DISPATCH_USERCTRLBUSOFF_UL)0x01)
+typedef uint8 CANIF_DISPATCH_USER_CTRL_BUS_OFF_UL;
+#define CAN_SM									((CANIF_DISPATCH_USER_CTRL_BUS_OFF_UL)0x00)
+#define CDD										((CANIF_DISPATCH_USER_CTRL_BUS_OFF_UL)0x01)
 
 /* This parameter defines the name of <User_ControllerBusOff>. This parameter depends on the parameter
 CANIF_USERCTRLBUSOFF_UL. If CANIF_USERCTRLBUSOFF_UL equals CAN_SM the name of <User_ControllerBusOff>
 is fixed. If CANIF_USERCTRLBUSOFF_UL equals CDD, the name of <User_ControllerBusOff> is selectable. */
-#if(CanIfDispatchUserCtrlBusOffUL==CAN_SM)
-	#define CanIfDispatchUserCtrlBusOffName		CanSM_ControllerBusOff
-#else if(CanIfDispatchUserCtrlBusOffUL==CDD)
-	#define CanIfDispatchUserCtrlBusOffName		Cdd_ControllerBusOff
+#if(CANIF_DISPATCH_USER_CTRL_BUS_OFF_UL==CAN_SM)
+	#define CANIF_DISPATCH__USER_CTRL_BUS_OFF_NAME					CanSM_ControllerBusOff
+#else if(CANIF_DISPATCH_USER_CTRL_BUS_OFF_UL==CDD)
+	#define CANIF_DISPATCH__USER_CTRL_BUS_OFF_NAME					Cdd_ControllerBusOff
 #endif
 
 /* This parameter defines the upper layer (UL) module to which the notifications of all ControllerTransition
 events from the CAN Driver modules have to be routed via <User_ControllerModeIndication>. */
-typedef uint8 CANIF_DISPATCH_USERCTRLMODEINDICATION_UL;
-#define CAN_SM									((CANIF_DISPATCH_USERCTRLMODEINDICATION_UL)0x00)
-#define CDD										((CANIF_DISPATCH_USERCTRLMODEINDICATION_UL)0x01)
+typedef uint8 CANIF_DISPATCH_USER_CTRL_MODE_INDICATION_UL;
+#define CAN_SM									((CANIF_DISPATCH_USER_CTRL_MODE_INDICATION_UL)0x00)
+#define CDD										((CANIF_DISPATCH_USER_CTRL_MODE_INDICATION_UL)0x01)
 
 /* This parameter defines the name of <User_ControllerModeIndication>. This parameter depends on the parameter
 CANIF_USERCTRLMODEINDICATION_UL. If CANIF_USERCTRLMODEINDICATION_UL equals CAN_SM the name of <User_ControllerModeIndication>
 is fixed. If CANIF_USERCTRLMODEINDICATION_UL equals CDD, the name of <User_ControllerModeIndication> is selectable. */
-#if(CanIfDispatchUserCtrlModeIndicationUL==CAN_SM)
-	#define CanIfDispatchUserCtrlModeIndicationName		CanSM_ControllerModeIndication
-#else if(CanIfDispatchUserCtrlModeIndicationUL==CDD)
-	#define CanIfDispatchUserCtrlModeIndicationName		Cdd_ControllerModeIndication
+#if(CANIF_DISPATCH_USER_CTRL_MODE_INDICATION_UL==CAN_SM)
+	#define CANIF_DISPATCH_USER_CTRL_MODE_INDICATION_NAME			CanSM_ControllerModeIndication
+#else if(CANIF_DISPATCH_USER_CTRL_MODE_INDICATION_UL==CDD)
+	#define CANIF_DISPATCH_USER_CTRL_MODE_INDICATION_NAME			Cdd_ControllerModeIndication
 #endif
 
 /* This parameter defines the upper layer (UL) module to which the notifications of all TransceiverTransition events from
 the CAN Transceiver Driver modules have to be routed via <User_TrcvModeIndication>. If no UL module is configured, no upper
 layer callback function will be called. */
-typedef uint8 CANIF_DISPATCH_USERTRCVMODEINDICATION_UL;
-#define CAN_SM									((CANIF_DISPATCH_USERTRCVMODEINDICATION_UL)0x00)
-#define CDD										((CANIF_DISPATCH_USERTRCVMODEINDICATION_UL)0x01)
+typedef uint8 CANIF_DISPATCH_USER_TRCV_MODE_INDICATION_UL;
+#define CAN_SM									((CANIF_DISPATCH_USER_TRCV_MODE_INDICATION_UL)0x00)
+#define CDD										((CANIF_DISPATCH_USER_TRCV_MODE_INDICATION_UL)0x01)
 
 /* This parameter defines the name of <User_TrcvModeIndication>. This parameter depends on the parameter
 CANIF_USERTRCVMODEINDICATION_UL. If CANIF_USERTRCVMODEINDICATION_UL equals CAN_SM the name of <User_TrcvModeIndication>
 is fixed. If CANIF_USERTRCVMODEINDICATION_UL equals CDD, the name of <User_TrcvModeIndication> is selectable. */
-#if(CanIfDispatchUserTrcvModeIndicationUL==CAN_SM)
-	#define CanIfDispatchUserTrcvModeIndicationName		CanSM_TransceiverModeIndication
-#else if(CanIfDispatchUserTrcvModeIndicationUL==CDD)
-	#define CanIfDispatchUserTrcvModeIndicationName		Cdd_TransceiverModeIndication
+#if(CANIF_DISPATCH_USER_TRCV_MODE_INDICATION_UL==CAN_SM)
+	#define CANIF_DISPATCH_USER_TRCV_MODE_INDICATION_NAME			CanSM_TransceiverModeIndication
+#else if(CANIF_DISPATCH_USER_TRCV_MODE_INDICATION_UL==CDD)
+	#define CANIF_DISPATCH_USER_TRCV_MODE_INDICATION_NAME			Cdd_TransceiverModeIndication
 #endif
 
 /* This parameter defines the upper layer (UL) module to which the notifications about positive former requested
 wake up sources have to be routed via <User_ValidateWakeupEvent>. If parameter CANIF_WAKEUP_CHECK_VALIDATION_API is
 disabled, this parameter cannot be configured. dependency: CANIF_WAKEUP_CHECK_VALIDATION_API */
-#if(CanIfPublicWakeupCheckValidSupport==STD_ON)
-	typedef uint8 CANIF_DISPATCH_USERVALIDATEWAKEUPEVENTUL;
+#if(CANIF_PUBLIC_WAKEUP_CHECK_VALID_SUPPORT==STD_ON)
+	typedef uint8 CANIF_DISPATCH_USER_VALIDATE_WAKEUP_EVENT_UL;
 	#define ECUM								((CANIF_DISPATCH_USERVALIDATEWAKEUPEVENTUL)0x00)
 	#define CDD									((CANIF_DISPATCH_USERVALIDATEWAKEUPEVENTUL)0x01)
 #endif
@@ -648,11 +682,11 @@ disabled, this parameter cannot be configured. dependency: CANIF_WAKEUP_CHECK_VA
 CANIF_USERVALIDATEWAKEUPEVENT_UL. CANIF_USERVALIDATEWAKEUPEVENT_UL equals ECUM the name of <User_ValidateWakeupEvent>
 is fixed. CANIF_USERVALIDATEWAKEUPEVENT_UL equals CDD, the name of <User_ValidateWakeupEvent> is selectable. If parameter 
 CANIF_WAKEUP_CHECK_VALIDATION_API is disabled, no <User_ValidateWakeupEvent> API can be configured. */
-#if(CanIfPublicWakeupCheckValidSupport==STD_ON)
-	#if(CanIfDispatchUserValidateWakeupEventUL==ECUM)
-		#define CanIfDispatchUserValidateWakeupEventName		EcuM_ValidateWakeupEvent
-	#else if(CanIfDispatchUserValidateWakeupEventUL==CDD)
-		#define CanIfDispatchUserValidateWakeupEventName		Cdd_ValidateWakeupEvent
+#if(CANIF_PUBLIC_WAKEUP_CHECK_VALID_SUPPORT==STD_ON)
+	#if(CANIF_DISPATCH_USER_VALIDATE_WAKEUP_EVENT_UL==ECUM)
+		#define CANIF_DISPATCH_USER_VALIDATE_WAKEUP_EVENT_NAME		EcuM_ValidateWakeupEvent
+	#else if(CANIF_DISPATCH_USER_VALIDATE_WAKEUP_EVENT_UL==CDD)
+		#define CANIF_DISPATCH_USER_VALIDATE_WAKEUP_EVENT_NAME		Cdd_ValidateWakeupEvent
 	#endif
 #endif
 
@@ -660,12 +694,12 @@ CANIF_WAKEUP_CHECK_VALIDATION_API is disabled, no <User_ValidateWakeupEvent> API
 Controller. Each controller of all connected CAN Driver modules shall
 be assigned to one specific ControllerId of the CanIf. Range:
 0..number of configured controllers of all CAN Driver modules*/
-#define CanIfCtrlIdValue						(255U)
+#define CANIF_CTRL_ID							(255U)
 
 /*This parameter defines if a respective controller of the referenced CAN
 Driver modules is queriable for wake up events.
 True: Enabled False: Disabled*/
-#define CanIfCtrlWakeupSupport					STD_OFF
+#define CANIF_CTRL_WAKEUP_SUPPORT				STD_OFF
 
 /*This parameter abstracts from the CAN Transceiver Driver specific
 parameter Transceiver. Each transceiver of all connected CAN
@@ -673,51 +707,51 @@ Transceiver Driver modules shall be assigned to one specific
 TransceiverId of the CanIf.
 Range: 0..number of configured transceivers of all CAN Transceiver
 Driver modules*/
-#define CanIfTrcvId0							(0U)
-#define CanIfTrcvId1							(1U)
+#define CANIF_TRCV_ID0							(0U)
+#define CANIF_TRCV_ID1							(1U)
 
 /*This parameter defines if a respective transceiver of the referenced
 CAN Transceiver Driver modules is queriable for wake up events.
 True: Enabled False: Disabled*/
-#define CanIfTrcvWakeupSupport					STD_OFF
+#define CANIF_TRCV_WAKEUP_SUPPORT				STD_OFF
 
 /*Selects the hardware receive objects by using the HRH range/list from
 CAN Driver configuration to define, for which HRH a software filtering
 has to be performed at during receive processing.
 True: Software filtering is enabled False: Software filtering is enabled*/
-#define CanIfHrhSoftwareFilter                  STD_ON
+#define CANIF_HRH_SOFTWARE_FILTER               STD_ON
 
 /*CAN Identifier used as base value in combination with
 CanIfHrhRangeMask for a masked ID range in which all CAN Ids shall
 pass the software filtering. The size of this parameter is limited by
 CanIfHrhRangeRxPduRangeCanIdType*/
-#define CanIfHrhRangeBaseId0               		(0U)
-#define CanIfHrhRangeBaseId1               		(1U)
+#define CANIF_HRH_RANGE_BASE_ID0           		(0U)
+#define CANIF_HRH_RANGE_BASE_ID1           		(1U)
 
 /*Used as mask value in combination with CanIfHrhRangeBaseId for a
 masked ID range in which all CAN Ids shall pass the software filtering.
 The size of this parameter is limited by
 CanIfHrhRangeRxPduRangeCanIdType.*/
-#define  CanIfHrhRangeMask0	                	(0U)
-#define  CanIfHrhRangeMask1	                	(1U)
+#define  CANIF_HRH_RANGE_MASK0                	(0U)
+#define  CANIF_HRH_RANGE_MASK1                	(1U)
 
 /*Lower CAN Identifier of a receive CAN L-PDU for identifier range
 definition, in which all CAN Ids shall pass the software filtering.*/
-#define  CanIfHrhRangeRxPduLowerCanId0	     	(0U)
-#define  CanIfHrhRangeRxPduLowerCanId1	     	(1U)
+#define  CANIF_HRH_RANGE_RX_PDU_LOWER_CAN_ID0	     				(0U)
+#define  CANIF_HRH_RANGE_RX_PDU_LOWER_CAN_ID1	     				(1U)
 
 /*Used as mask value in combination with CanIfHrhRangeBaseId for a
 masked ID range in which all CAN Ids shall pass the software filtering.
 The size of this parameter is limited by
 CanIfHrhRangeRxPduRangeCanIdType.*/
-typedef uint8 CANIF_HRHRANGE_RXPDU_RANGE_CANID_TYPE;
-#define EXTENDED								((CANIF_HRHRANGE_RXPDU_RANGE_CANID_TYPE)0x00)
-#define STANDARD								((CANIF_HRHRANGE_RXPDU_RANGE_CANID_TYPE)0x01)
+typedef uint8 CANIF_HRH_RANGE_RX_PDU_RANGE_CAN_ID_TYPE;
+#define EXTENDED								((CANIF_HRH_RANGE_RX_PDU_RANGE_CAN_ID_TYPE)0x00)
+#define STANDARD								((CANIF_HRH_RANGE_RX_PDU_RANGE_CAN_ID_TYPE)0x01)
 
 /*Upper CAN Identifier of a receive CAN L-PDU for identifier range
 definition, in which all CAN Ids shall pass the software filtering.*/
-#define CanIfHrhRangeRxPduUpperCanId0      		(0U)
-#define CanIfHrhRangeRxPduUpperCanId1      		(1U)
+#define CANIF_HRH_RANGE_RX_PDU_UPPER_CAN_ID0			    		(0U)
+#define CANIF_HRH_RANGE_RX_PDU_UPPER_CAN_ID1      					(1U)
 
 /*This parameter defines the number of CanIf Tx L-PDUs which can be
 buffered in one Txbuffer. If this value equals 0, the CanIf does not
@@ -725,12 +759,12 @@ perform Txbuffering for the CanIf Tx L-PDUs which are assigned to this
 Txbuffer. If CanIfPublicTxBuffering equals False, this parameter equals
 0 for all TxBuffer. If the CanHandleType of the referred HTH equals
 FULL, this parameter equals 0 for this TxBuffer.*/
-#if(CanIfPublicTxBuffering==STD_OFF)
-	#define CanIfBufferSizeValue                     (0U)
+#if(CANIF_PUBLIC_TX_BUFFERING==STD_OFF)
+	#define CANIF_BUFFER_SIZE                  (0U)
 #else if(CanHardwareObject.CanHandleType==FULL)
-	#define CanIfBufferSizeValue                     (0U)
+	#define CANIF_BUFFER_SIZE                  (0U)
 #else	/* any value, implementation dependant */
-	#define CanIfBufferSizeValue                     (255U)
+	#define CANIF_BUFFER_SIZE                  (255U)
 #endif
 
 #endif /* __CANIF_CFG_H__ */

--- a/Software/bsw/gen/CanIf_Cfg.h
+++ b/Software/bsw/gen/CanIf_Cfg.h
@@ -64,11 +64,11 @@
 //	parameter CAN_HANDLE_TYPE of the CAN Driver module via
 //	CANIF_HRH_HANDLETYPE_REF for at least one HRH.
 //*****************************************************************************
-typedef uint8 CANIF_PRIVATE_SOFTWARE_FILTER_TYPE;
-#define BINARY									((CANIF_PRIVATE_SOFTWARE_FILTER_TYPE)0x00)
-#define INDEX									((CANIF_PRIVATE_SOFTWARE_FILTER_TYPE)0x01)
-#define LINEAR									((CANIF_PRIVATE_SOFTWARE_FILTER_TYPE)0x02)
-#define TABLE									((CANIF_PRIVATE_SOFTWARE_FILTER_TYPE)0x03)
+typedef uint8 CanIfPrivateSoftwareFilterTypeType;
+#define BINARY									((CanIfPrivateSoftwareFilterTypeType)0x00)
+#define INDEX									((CanIfPrivateSoftwareFilterTypeType)0x01)
+#define LINEAR									((CanIfPrivateSoftwareFilterTypeType)0x02)
+#define TABLE									((CanIfPrivateSoftwareFilterTypeType)0x03)
 
 //*****************************************************************************
 //  Defines whether TTCAN is supported.
@@ -111,9 +111,9 @@ typedef uint8 CANIF_PRIVATE_SOFTWARE_FILTER_TYPE;
 //	hardware unit. For CAN hardware units with more than 255 HW objects
 //	the extended range shall be used (UINT16).
 //*****************************************************************************
-typedef uint16 CANIF_PUBLIC_HANDLE_TYPE_ENUM;
-#define UINT16 									((CANIF_PUBLIC_HANDLE_TYPE_ENUM)0xFFFF)
-#define UINT8									((CANIF_PUBLIC_HANDLE_TYPE_ENUM)0x0FF)
+typedef uint16 CanIfPublicHandleTypeEnumType;
+#define UINT16 									((CanIfPublicHandleTypeEnumType)0xFFFF)
+#define UINT8									((CanIfPublicHandleTypeEnumType)0x0FF)
 
 //*****************************************************************************
 //  Selects support of Pretended Network features in CanIf.
@@ -284,11 +284,11 @@ Range: 	EXTENDED_CAN CAN 		frame with extended identifier (29 bits)
 		EXTENDED_FD_CAN CAN FD 	frame with extended identifier (29 bits)
 		STANDARD_CAN CAN 		frame with standard identifier (11 bits)
 		STANDARD_FD_CAN CAN FD 	frame with standard identifier (11 bits)*/
-typedef uint8 CANIF_TX_PDU_CAN_ID_TYPE;
-#define EXTENDED_CAN							((CANIF_TX_PDU_CAN_ID_TYPE)0x00U)
-#define EXTENDED_FD_CAN							((CANIF_TX_PDU_CAN_ID_TYPE)0x01U)
-#define STANDARD_CAN							((CANIF_TX_PDU_CAN_ID_TYPE)0x02U)
-#define STANDARD_FD_CAN							((CANIF_TX_PDU_CAN_ID_TYPE)0x03U)
+typedef uint8 CanIfTxPduCanIdTypeType;
+#define EXTENDED_CAN							((CanIfTxPduCanIdTypeType)0x00U)
+#define EXTENDED_FD_CAN							((CanIfTxPduCanIdTypeType)0x01U)
+#define STANDARD_CAN							((CanIfTxPduCanIdTypeType)0x02U)
+#define STANDARD_FD_CAN							((CanIfTxPduCanIdTypeType)0x03U)
 
 /* ECU wide unique, symbolic handle for transmit CAN L-SDU.
 Range: 0..max. number of CantTxPduIds. Range: 0 - 4294967295*/
@@ -322,9 +322,9 @@ has to be either PDUR or CDD and CanIfTxPduUserTriggerTransmitName has to be spe
 /* Defines the type of each transmit CAN L-PDU.
 Range:	DYNAMIC 	CAN ID is defined at runtime.
 		STATIC 		CAN ID is defined at compile-time. */
-typedef uint8 CANIF_TX_PDU_TYPE;
-#define DYNAMIC									((CANIF_TX_PDU_TYPE)0x00U)
-#define STATIC									((CANIF_TX_PDU_TYPE)0x01U)
+typedef uint8 CanIfTxPduTypeType;
+#define DYNAMIC									((CanIfTxPduTypeType)0x00U)
+#define STATIC									((CanIfTxPduTypeType)0x01U)
 
 /* This parameter defines the upper layer (UL) module to which the confirmation of
 the successfully transmitted CANTXPDUID has to be routed via the <User_TxConfirmation>.
@@ -345,15 +345,15 @@ layer modules have to be configured for Trigger Transmit. Therefore,
 <User_TriggerTransmit>() will not be called and CanIfTxPduUserTxConfirmationUL
 as well as CanIfTxPduUserTriggerTransmitName need not to be configured. */
 #if(CANIF_TX_PDU_TRIGGER_TRANSMIT==STD_ON)
-	typedef uint8 CANIF_TX_PDU_USER_TX_CONFIRMATION_UL;
-	#define CAN_NM								((CANIF_TX_PDU_USER_TX_CONFIRMATION_UL)0x00U)
-	#define CAN_TP								((CANIF_TX_PDU_USER_TX_CONFIRMATION_UL)0x01U)
-	#define CAN_TSYN							((CANIF_TX_PDU_USER_TX_CONFIRMATION_UL)0x02U)
-	#define CDD									((CANIF_TX_PDU_USER_TX_CONFIRMATION_UL)0x03U)
-	#define J1939NM								((CANIF_TX_PDU_USER_TX_CONFIRMATION_UL)0x04U)
-	#define J1939TP								((CANIF_TX_PDU_USER_TX_CONFIRMATION_UL)0x05U)
-	#define PDUR								((CANIF_TX_PDU_USER_TX_CONFIRMATION_UL)0x06U)
-	#define XCP									((CANIF_TX_PDU_USER_TX_CONFIRMATION_UL)0x07U)
+	typedef uint8 CanIfTxPduUserTxConfirmationULType;
+	#define CAN_NM								((CanIfTxPduUserTxConfirmationULType)0x00U)
+	#define CAN_TP								((CanIfTxPduUserTxConfirmationULType)0x01U)
+	#define CAN_TSYN							((CanIfTxPduUserTxConfirmationULType)0x02U)
+	#define CDD									((CanIfTxPduUserTxConfirmationULType)0x03U)
+	#define J1939NM								((CanIfTxPduUserTxConfirmationULType)0x04U)
+	#define J1939TP								((CanIfTxPduUserTxConfirmationULType)0x05U)
+	#define PDUR								((CanIfTxPduUserTxConfirmationULType)0x06U)
+	#define XCP									((CanIfTxPduUserTxConfirmationULType)0x07U)
 #endif
 
 /* This parameter defines the name of the <User_TriggerTransmit>. This parameter depends on the parameter
@@ -452,16 +452,16 @@ Range: 	EXTENDED_CAN 			CAN 2.0 or CAN FD frame with extended identifier (29 bit
 		STANDARD_FD_CAN 		CAN FD frame with standard identifier (11 bits)
 		STANDARD_NO_FD_CAN 		CAN 2.0 frame with standard identifier (11 bits)
 dependency: If CanIfRxPduDataLength > 8 then CanIfRxPduCanIdType must not be STANDARD_NO_FD_CAN or EXTENDED_NO_FD_CAN */
-typedef uint8 CANIF_RX_PDU_CAN_ID_TYPE;
-#define EXTENDED_CAN							((CANIF_RX_PDU_CAN_ID_TYPE)0x00U)
-#define EXTENDED_FD_CAN							((CANIF_RX_PDU_CAN_ID_TYPE)0x01U)
+typedef uint8 CanIfRxPduCanIdTypeType;
+#define EXTENDED_CAN							((CanIfRxPduCanIdTypeType)0x00U)
+#define EXTENDED_FD_CAN							((CanIfRxPduCanIdTypeType)0x01U)
 #if(CanIfRxPduDataLength <= 8)
-	#define EXTENDED_NO_FD_CAN					((CANIF_RX_PDU_CAN_ID_TYPE)0x02U)
+	#define EXTENDED_NO_FD_CAN					((CanIfRxPduCanIdTypeType)0x02U)
 #endif
-#define STANDARD_CAN							((CANIF_RX_PDU_CAN_ID_TYPE)0x03U)
-#define STANDARD_FD_CAN							((CANIF_RX_PDU_CAN_ID_TYPE)0x04U)
+#define STANDARD_CAN							((CanIfRxPduCanIdTypeType)0x03U)
+#define STANDARD_FD_CAN							((CanIfRxPduCanIdTypeType)0x04U)
 #if(CanIfRxPduDataLength <= 8)
-	#define STANDARD_NO_FD_CAN					((CANIF_RX_PDU_CAN_ID_TYPE)0x05U)
+	#define STANDARD_NO_FD_CAN					((CanIfRxPduCanIdTypeType)0x05U)
 #endif
 
 /* Data length of the received CAN L-PDUs used by the CAN Interface. This information is
@@ -512,15 +512,15 @@ Note: If receive indications are not necessary or no upper layer modules
 are configured for receive indications and thus <User_RxIndication>()
 shall not be called, CANIF_RXPDU_USERRXINDICATION_UL and
 CANIF_RXPDU_USERRXINDICATION_NAME need not to be configured. */
-typedef uint8 CANIF_RX_PDU_USER_RX_INDICATION_UL;
-#define CAN_NM									((CANIF_RX_PDU_USER_RX_INDICATION_UL)0x00U)
-#define CAN_TP									((CANIF_RX_PDU_USER_RX_INDICATION_UL)0x01U)
-#define CAN_TSYN								((CANIF_RX_PDU_USER_RX_INDICATION_UL)0x02U)
-#define CDD										((CANIF_RX_PDU_USER_RX_INDICATION_UL)0x03U)
-#define J1939NM									((CANIF_RX_PDU_USER_RX_INDICATION_UL)0x04U)
-#define J1939TP									((CANIF_RX_PDU_USER_RX_INDICATION_UL)0x05U)
-#define PDUR									((CANIF_RX_PDU_USER_RX_INDICATION_UL)0x06U)
-#define XCP										((CANIF_RX_PDU_USER_RX_INDICATION_UL)0x07U)
+typedef uint8 CanIfRxPduUserRxIndicationULType;
+#define CAN_NM									((CanIfRxPduUserRxIndicationULType)0x00U)
+#define CAN_TP									((CanIfRxPduUserRxIndicationULType)0x01U)
+#define CAN_TSYN								((CanIfRxPduUserRxIndicationULType)0x02U)
+#define CDD										((CanIfRxPduUserRxIndicationULType)0x03U)
+#define J1939NM									((CanIfRxPduUserRxIndicationULType)0x04U)
+#define J1939TP									((CanIfRxPduUserRxIndicationULType)0x05U)
+#define PDUR									((CanIfRxPduUserRxIndicationULType)0x06U)
+#define XCP										((CanIfRxPduUserRxIndicationULType)0x07U)
 
 /* This parameter defines the name of the <User_RxIndication>. This parameter depends
 on the parameter CanIfRxPduUserRxIndicationUL. If CanIfRxPduUserRxIndicationUL equals
@@ -562,9 +562,9 @@ Range: 0 - 536870911 */
 from the Driver modules have to be routed. If CANIF_PUBLIC_PN_SUPPORT equals False, this
 parameter shall not be configurable. dependency: CANIF_PUBLIC_PN_SUPPORT */
 #if(CANIF_PUBLIC_PN_SUPPORT==STD_ON)
-	typedef uint8 CANIF_DISPATCH_USER_CHECK_TRCV_WAKE_FLAG_INDICATION_UL;
-	#define CAN_SM								((CANIF_DISPATCH_USER_CHECK_TRCV_WAKE_FLAG_INDICATION_UL)0x00)
-	#define CDD									((CANIF_DISPATCH_USER_CHECK_TRCV_WAKE_FLAG_INDICATION_UL)0x01)
+	typedef uint8 CanIfDispatchUserCheckTrcvWakeFlagIndicationULType;
+	#define CAN_SM								((CanIfDispatchUserCheckTrcvWakeFlagIndicationULType)0x00)
+	#define CDD									((CanIfDispatchUserCheckTrcvWakeFlagIndicationULType)0x01)
 #endif
 
 /* This parameter defines the name of <User_CheckTrcvWakeFlagIndication>. If
@@ -573,9 +573,9 @@ CanIfDispatchUserCheckTrcvWakeFlagIndicationUL equals CAN_SM the name of
 If CanIfPublicPnSupport equals False, this parameter shall not be configurable.
 dependency: CANIF_DISPATCH_USERCHECKTRCVWAKEFLAGINDICATION_UL, CANIF_PUBLIC_PN_SUPPORT */
 #if(CANIF_PUBLIC_PN_SUPPORT==STD_ON)
-	#if(CANIF_DISPATCH_USER_CHECK_TRCV_WAKE_FLAG_INDICATION_UL==CAN_SM)
+	#if(CanIfDispatchUserCheckTrcvWakeFlagIndicationUL==CAN_SM)
 		#define CANIF_DISPATCH_USER_CHECK_TRCV_WAKE_FLAG_INDICATION_NAME 	CanSM_CheckTrcvWakeFlagIndication
-	#else if(CANIF_DISPATCH_USER_CHECK_TRCV_WAKE_FLAG_INDICATION_UL==CDD)
+	#else if(CanIfDispatchUserCheckTrcvWakeFlagIndicationUL==CDD)
 		#define CANIF_DISPATCH_USER_CHECK_TRCV_WAKE_FLAG_INDICATION_NAME	Cdd_CheckTrcvWakeFlagIndication
 	#endif
 #endif
@@ -584,9 +584,9 @@ dependency: CANIF_DISPATCH_USERCHECKTRCVWAKEFLAGINDICATION_UL, CANIF_PUBLIC_PN_S
 from the Driver modules have to be routed. If CANIF_PUBLIC_PN_SUPPORT equals False, this
 parameter shall not be configurable. dependency: CANIF_PUBLIC_PN_SUPPORT */
 #if(CANIF_PUBLIC_PN_SUPPORT==STD_ON)
-	typedef uint8 CANIF_DISPATCH_USER_CLEAR_TRCV_WUF_FLAG_INDICATION_UL;
-	#define CAN_SM								((CANIF_DISPATCH_USER_CLEAR_TRCV_WUF_FLAG_INDICATION_UL)0x00)
-	#define CDD									((CANIF_DISPATCH_USER_CLEAR_TRCV_WUF_FLAG_INDICATION_UL)0x01)
+	typedef uint8 CanIfDispatchUserClearTrcvWufFlagIndicationULType;
+	#define CAN_SM								((CanIfDispatchUserClearTrcvWufFlagIndicationULType)0x00)
+	#define CDD									((CanIfDispatchUserClearTrcvWufFlagIndicationULType)0x01)
 #endif
 
 /* This parameter defines the name of <User_ClearTrcvWufFlagIndication>. If
@@ -594,9 +594,9 @@ CanIfDispatchUserClearTrcvWufFlagIndicationUL equals CAN_SM the name of
 <User_ClearTrcvWufFlagIndication> is fixed. If it equals CDD, the name is selectable.
 If CANIF_PUBLIC_PN_SUPPORT equals False, this parameter shall not be configurable. */
 #if(CANIF_PUBLIC_PN_SUPPORT==STD_ON)
-	#if(CANIF_DISPATCH_USER_CLEAR_TRCV_WUF_FLAG_INDICATION_UL==CAN_SM)
+	#if(CanIfDispatchUserClearTrcvWufFlagIndicationUL==CAN_SM)
 		#define CANIF_DISPATCH_USER_CLEAR_TRCV_WUF_FLAG_INDICATION_NAME		CanSM_ClearTrcvWufFlagIndication
-	#else if(CANIF_DISPATCH_USER_CLEAR_TRCV_WUF_FLAG_INDICATION_UL==CDD)
+	#else if(CanIfDispatchUserClearTrcvWufFlagIndicationUL==CDD)
 		#define CANIF_DISPATCH_USER_CLEAR_TRCV_WUF_FLAG_INDICATION_NAME		Cdd_ClearTrcvWufFlagIndication
 	#endif
 #endif
@@ -605,9 +605,9 @@ If CANIF_PUBLIC_PN_SUPPORT equals False, this parameter shall not be configurabl
 from the Driver modules have to be routed. If CANIF_PUBLIC_PN_SUPPORT equals False, this
 parameter shall not be configurable. dependency: CANIF_PUBLIC_PN_SUPPORT */
 #if(CANIF_PUBLIC_PN_SUPPORT==STD_ON)
-	typedef uint8 CANIF_DISPATCH_USER_CONFIRM_PN_AVAILABILITY_UL;
-	#define CAN_SM								((CANIF_DISPATCH_USER_CONFIRM_PN_AVAILABILITY_UL)0x00)
-	#define CDD									((CANIF_DISPATCH_USER_CONFIRM_PN_AVAILABILITY_UL)0x01)
+	typedef uint8 CanIfDispatchUserConfirmPnAvailabilityULType;
+	#define CAN_SM								((CanIfDispatchUserConfirmPnAvailabilityULType)0x00)
+	#define CDD									((CanIfDispatchUserConfirmPnAvailabilityULType)0x01)
 #endif
 
 /* This parameter defines the name of <User_ConfirmPnAvailability>. If
@@ -615,9 +615,9 @@ CanIfDispatchUserConfirmPnAvailabilityUL equals CAN_SM the name of
 <User_ConfirmPnAvailability> is fixed. If it equals CDD, the name is selectable.
 If CANIF_PUBLIC_PN_SUPPORT equals False, this parameter shall not be configurable. */
 #if(CANIF_PUBLIC_PN_SUPPORT==STD_ON)
-	#if(CANIF_DISPATCH_USER_CONFIRM_PN_AVAILABILITY_UL==CAN_SM)
+	#if(CanIfDispatchUserConfirmPnAvailabilityUL==CAN_SM)
 		#define CANIF_DISPATCH_USER_CONFIRM_PN_AVAILABILITY_NAME		CanSM_ConfirmPnAvailability
-	#else if(CANIF_DISPATCH_USER_CONFIRM_PN_AVAILABILITY_UL==CDD)
+	#else if(CanIfDispatchUserConfirmPnAvailabilityUL==CDD)
 		#define CANIF_DISPATCH_USER_CONFIRM_PN_AVAILABILITY_NAME		Cdd_ConfirmPnAvailability
 	#endif
 #endif
@@ -625,47 +625,47 @@ If CANIF_PUBLIC_PN_SUPPORT equals False, this parameter shall not be configurabl
 /* This parameter defines the upper layer (UL) module to which the notifications of all
 ControllerBusOff events from the CAN Driver modules have to be routed via <User_ControllerBusOff>.
 There is no possibility to configure no upper layer (UL) module as the provider of <User_ControllerBusOff>. */
-typedef uint8 CANIF_DISPATCH_USER_CTRL_BUS_OFF_UL;
-#define CAN_SM									((CANIF_DISPATCH_USER_CTRL_BUS_OFF_UL)0x00)
-#define CDD										((CANIF_DISPATCH_USER_CTRL_BUS_OFF_UL)0x01)
+typedef uint8 CanIfDispatchUserCtrlBusOffULType;
+#define CAN_SM									((CanIfDispatchUserCtrlBusOffULType)0x00)
+#define CDD										((CanIfDispatchUserCtrlBusOffULType)0x01)
 
 /* This parameter defines the name of <User_ControllerBusOff>. This parameter depends on the parameter
 CANIF_USERCTRLBUSOFF_UL. If CANIF_USERCTRLBUSOFF_UL equals CAN_SM the name of <User_ControllerBusOff>
 is fixed. If CANIF_USERCTRLBUSOFF_UL equals CDD, the name of <User_ControllerBusOff> is selectable. */
-#if(CANIF_DISPATCH_USER_CTRL_BUS_OFF_UL==CAN_SM)
+#if(CanIfDispatchUserCtrlBusOffUL==CAN_SM)
 	#define CANIF_DISPATCH__USER_CTRL_BUS_OFF_NAME					CanSM_ControllerBusOff
-#else if(CANIF_DISPATCH_USER_CTRL_BUS_OFF_UL==CDD)
+#else if(CanIfDispatchUserCtrlBusOffUL==CDD)
 	#define CANIF_DISPATCH__USER_CTRL_BUS_OFF_NAME					Cdd_ControllerBusOff
 #endif
 
 /* This parameter defines the upper layer (UL) module to which the notifications of all ControllerTransition
 events from the CAN Driver modules have to be routed via <User_ControllerModeIndication>. */
-typedef uint8 CANIF_DISPATCH_USER_CTRL_MODE_INDICATION_UL;
-#define CAN_SM									((CANIF_DISPATCH_USER_CTRL_MODE_INDICATION_UL)0x00)
-#define CDD										((CANIF_DISPATCH_USER_CTRL_MODE_INDICATION_UL)0x01)
+typedef uint8 CanIfDispatchUserCtrlModeIndicationULType;
+#define CAN_SM									((CanIfDispatchUserCtrlModeIndicationULType)0x00)
+#define CDD										((CanIfDispatchUserCtrlModeIndicationULType)0x01)
 
 /* This parameter defines the name of <User_ControllerModeIndication>. This parameter depends on the parameter
 CANIF_USERCTRLMODEINDICATION_UL. If CANIF_USERCTRLMODEINDICATION_UL equals CAN_SM the name of <User_ControllerModeIndication>
 is fixed. If CANIF_USERCTRLMODEINDICATION_UL equals CDD, the name of <User_ControllerModeIndication> is selectable. */
-#if(CANIF_DISPATCH_USER_CTRL_MODE_INDICATION_UL==CAN_SM)
+#if(CanIfDispatchUserCtrlModeIndicationUL==CAN_SM)
 	#define CANIF_DISPATCH_USER_CTRL_MODE_INDICATION_NAME			CanSM_ControllerModeIndication
-#else if(CANIF_DISPATCH_USER_CTRL_MODE_INDICATION_UL==CDD)
+#else if(CanIfDispatchUserCtrlModeIndicationUL==CDD)
 	#define CANIF_DISPATCH_USER_CTRL_MODE_INDICATION_NAME			Cdd_ControllerModeIndication
 #endif
 
 /* This parameter defines the upper layer (UL) module to which the notifications of all TransceiverTransition events from
 the CAN Transceiver Driver modules have to be routed via <User_TrcvModeIndication>. If no UL module is configured, no upper
 layer callback function will be called. */
-typedef uint8 CANIF_DISPATCH_USER_TRCV_MODE_INDICATION_UL;
-#define CAN_SM									((CANIF_DISPATCH_USER_TRCV_MODE_INDICATION_UL)0x00)
-#define CDD										((CANIF_DISPATCH_USER_TRCV_MODE_INDICATION_UL)0x01)
+typedef uint8 CanIfDispatchUserTrcvModeIndicationULType;
+#define CAN_SM									((CanIfDispatchUserTrcvModeIndicationULType)0x00)
+#define CDD										((CanIfDispatchUserTrcvModeIndicationULType)0x01)
 
 /* This parameter defines the name of <User_TrcvModeIndication>. This parameter depends on the parameter
 CANIF_USERTRCVMODEINDICATION_UL. If CANIF_USERTRCVMODEINDICATION_UL equals CAN_SM the name of <User_TrcvModeIndication>
 is fixed. If CANIF_USERTRCVMODEINDICATION_UL equals CDD, the name of <User_TrcvModeIndication> is selectable. */
-#if(CANIF_DISPATCH_USER_TRCV_MODE_INDICATION_UL==CAN_SM)
+#if(CanIfDispatchUserTrcvModeIndicationUL==CAN_SM)
 	#define CANIF_DISPATCH_USER_TRCV_MODE_INDICATION_NAME			CanSM_TransceiverModeIndication
-#else if(CANIF_DISPATCH_USER_TRCV_MODE_INDICATION_UL==CDD)
+#else if(CanIfDispatchUserTrcvModeIndicationUL==CDD)
 	#define CANIF_DISPATCH_USER_TRCV_MODE_INDICATION_NAME			Cdd_TransceiverModeIndication
 #endif
 
@@ -673,9 +673,9 @@ is fixed. If CANIF_USERTRCVMODEINDICATION_UL equals CDD, the name of <User_TrcvM
 wake up sources have to be routed via <User_ValidateWakeupEvent>. If parameter CANIF_WAKEUP_CHECK_VALIDATION_API is
 disabled, this parameter cannot be configured. dependency: CANIF_WAKEUP_CHECK_VALIDATION_API */
 #if(CANIF_PUBLIC_WAKEUP_CHECK_VALID_SUPPORT==STD_ON)
-	typedef uint8 CANIF_DISPATCH_USER_VALIDATE_WAKEUP_EVENT_UL;
-	#define ECUM								((CANIF_DISPATCH_USERVALIDATEWAKEUPEVENTUL)0x00)
-	#define CDD									((CANIF_DISPATCH_USERVALIDATEWAKEUPEVENTUL)0x01)
+	typedef uint8 CanIfDispatchUserValidateWakeupEventULType;
+	#define ECUM								((CanIfDispatchUserValidateWakeupEventULType)0x00)
+	#define CDD									((CanIfDispatchUserValidateWakeupEventULType)0x01)
 #endif
 
 /* This parameter defines the name of <User_ValidateWakeupEvent>. This parameter depends on the parameter
@@ -683,9 +683,9 @@ CANIF_USERVALIDATEWAKEUPEVENT_UL. CANIF_USERVALIDATEWAKEUPEVENT_UL equals ECUM t
 is fixed. CANIF_USERVALIDATEWAKEUPEVENT_UL equals CDD, the name of <User_ValidateWakeupEvent> is selectable. If parameter 
 CANIF_WAKEUP_CHECK_VALIDATION_API is disabled, no <User_ValidateWakeupEvent> API can be configured. */
 #if(CANIF_PUBLIC_WAKEUP_CHECK_VALID_SUPPORT==STD_ON)
-	#if(CANIF_DISPATCH_USER_VALIDATE_WAKEUP_EVENT_UL==ECUM)
+	#if(CanIfDispatchUserValidateWakeupEventUL==ECUM)
 		#define CANIF_DISPATCH_USER_VALIDATE_WAKEUP_EVENT_NAME		EcuM_ValidateWakeupEvent
-	#else if(CANIF_DISPATCH_USER_VALIDATE_WAKEUP_EVENT_UL==CDD)
+	#else if(CanIfDispatchUserValidateWakeupEventUL==CDD)
 		#define CANIF_DISPATCH_USER_VALIDATE_WAKEUP_EVENT_NAME		Cdd_ValidateWakeupEvent
 	#endif
 #endif
@@ -744,9 +744,9 @@ definition, in which all CAN Ids shall pass the software filtering.*/
 masked ID range in which all CAN Ids shall pass the software filtering.
 The size of this parameter is limited by
 CanIfHrhRangeRxPduRangeCanIdType.*/
-typedef uint8 CANIF_HRH_RANGE_RX_PDU_RANGE_CAN_ID_TYPE;
-#define EXTENDED								((CANIF_HRH_RANGE_RX_PDU_RANGE_CAN_ID_TYPE)0x00)
-#define STANDARD								((CANIF_HRH_RANGE_RX_PDU_RANGE_CAN_ID_TYPE)0x01)
+typedef uint8 CanIfHrhRangeRxPduRangeCanIdTypeType;
+#define EXTENDED								((CanIfHrhRangeRxPduRangeCanIdTypeType)0x00)
+#define STANDARD								((CanIfHrhRangeRxPduRangeCanIdTypeType)0x01)
 
 /*Upper CAN Identifier of a receive CAN L-PDU for identifier range
 definition, in which all CAN Ids shall pass the software filtering.*/

--- a/Software/bsw/static/COM/CanIf/inc/CanIf.h
+++ b/Software/bsw/static/COM/CanIf/inc/CanIf.h
@@ -79,22 +79,22 @@ typedef struct {
 						INDEX 	Selects Index Filter method.
 						LINEAR 	Selects Linear Filter method.
 						TABLE 	Selects Table Filter method.*/
-				uint8  CanIfPrivateSoftwareFilter;
-}CanIfPrivateCfg;
+				CANIF_PRIVATE_SOFTWARE_FILTER_TYPE  CanIfPrivateSoftwareFilterType;
+}CanIfPrivateCfgType;
 
 typedef struct {
 				/* Defines header files for callback functions which shall be included in
 				case of CDDs. Range of characters is 1.. 32. 
 				Type: EcucStringParamDef*/
-				uint8 CanIfPublicCddHeaderFileStr[CanIfPublicCddHeaderFile];
-}CanIfPublicCfg;
+				uint8 CanIfPublicCddHeaderFile[CANIF_PUBLIC_CDD_HEADER_FILE];
+}CanIfPublicCfgType;
  
 typedef struct {
 				/* Check with the Author the change i have made before comitting */
 				/*	Selects the CAN Interface specific configuration setup. This type of the external data structure shall 
 				contain the post build initialization data for the CAN Interface for all underlying CAN Dirvers.
 				constant to CanIf_ConfigType*/
-				uint8 CanIfInitCfgSetStr[CanIfInitCfgSet];
+				uint8 CanIfInitCfgSet[CANIF_INIT_CFG_SET];
 				
 				/* Maximum total size of all Tx buffers. This parameter is needed only in
 				case of post-build loadable implementation using static memory
@@ -144,7 +144,7 @@ typedef struct {
 				CAN_ID_32. */
 				CanIfTxPduCfg	CanIfTxPduConfig;
 				
-}CanIfInitCfg;
+}CanIfInitCfgType;
 
 typedef struct {
 				/* CAN Identifier of transmit CAN L-PDUs used by the CAN Driver for
@@ -167,7 +167,7 @@ typedef struct {
 						EXTENDED_FD_CAN CAN FD 	frame with extended identifier (29 bits)
 						STANDARD_CAN CAN 		frame with standard identifier (11 bits)
 						STANDARD_FD_CAN CAN FD 	frame with standard identifier (11 bits) */
-				uint8 CanIfTxPduCanIdType;
+				CANIF_TX_PDU_CAN_ID_TYPE CanIfTxPduCanIdType;
 				
 				/* ECU wide unique, symbolic handle for transmit CAN L-SDU.
 				Range: 0..max. number of CantTxPduIds */
@@ -179,7 +179,7 @@ typedef struct {
 				the corresponding controller applies no CanIfPnFilter.
 				dependency: This parameter shall only be configurable if
 				CanIfPublicPnSupport equals True. */
-				#if(CanIfPublicPnSupport==STD_ON)
+				#if(CANIF_PUBLIC_PN_SUPPORT==STD_ON)
 					uint8 CanIfTxPduPnFilterPdu;
 				#endif
 				
@@ -187,7 +187,7 @@ typedef struct {
 				L-SDU for reading its notification status.
 				True: Enabled False: Disabled
 				dependency: CANIF_READTXPDU_NOTIFY_STATUS_API must be enabled.*/
-				#if(CANIF_READTXPDU_NOTIFY_STATUS_API==STD_ON)
+				#if(CANIF_TX_PDU_READ_NOTIFY_STATUS==STD_ON)
 					uint8 CanIfTxPduReadNotifyStatus;
 				#endif
 				
@@ -202,7 +202,7 @@ typedef struct {
 				/* Defines the type of each transmit CAN L-PDU.
 				Range:	DYNAMIC 	CAN ID is defined at runtime.
 						STATIC 		CAN ID is defined at compile-time. */
-				uint8 CanIfTxPduType;
+				CANIF_TX_PDU_TYPE CanIfTxPduType;
 				
 				/* This parameter defines the upper layer (UL) module to which the confirmation of
 				the successfully transmitted CANTXPDUID has to be routed via the <User_TxConfirmation>.
@@ -223,7 +223,7 @@ typedef struct {
 				<User_TriggerTransmit>() will not be called and CanIfTxPduUserTxConfirmationUL
 				as well as CanIfTxPduUserTriggerTransmitName need not to be configured. */
 				#if(CANIF_TXPDU_TRIGGERTRANSMIT==STD_ON)
-					uint8 CanIfTxPduUserTxConfirmationUL;
+					CANIF_TX_PDU_USER_TX_CONFIRMATION_UL CanIfTxPduUserTxConfirmationUL;
 				#endif
 				
 				/* Configurable reference to a CanIf buffer configuration. CanIfBufferCfg */
@@ -232,7 +232,7 @@ typedef struct {
 				/* Reference to the "global" Pdu structure to allow harmonization of handle IDs in the COM-Stack.
 				//Pdu* CanIfTxPduRef;
 				will be configured in implementation */
-}CanIfTxPduCfg;
+}CanIfTxPduCfgType;
 
 typedef struct{
 				/* CAN Identifier of Receive CAN L-PDUs used by the CAN Interface.
@@ -257,7 +257,7 @@ typedef struct{
 						STANDARD_CAN 			CAN 2.0 or CAN FD frame with standard identifier (11 bits)
 						STANDARD_FD_CAN 		CAN FD frame with standard identifier (11 bits)
 						STANDARD_NO_FD_CAN 		CAN 2.0 frame with standard identifier (11 bits) */
-				uint8 CanIfRxPduCanIdType;
+				CANIF_RX_PDU_CAN_ID_TYPE CanIfRxPduCanIdType;
 				
 				/* Data length of the received CAN L-PDUs used by the CAN Interface.
 				This information is used for Data Length Check. Additionally it might
@@ -273,7 +273,7 @@ typedef struct{
 				/* Enables and disables the Rx buffering for reading of received L-SDU
 				data. True: Enabled False: Disabled
 				dependency: CANIF_CANPDUID_READDATA_API must be enabled */
-				#if(CANIF_CANPDUID_READDATA_API==STD_ON)
+				#if(CANIF_CAN_PDU_ID_READ_DATA_API==STD_ON)
 					uint8 CanIfRxPduReadData;
 				#endif
 				
@@ -281,7 +281,7 @@ typedef struct{
 				for reading its notification status.
 				True: Enabled False: Disabled
 				dependency: CANIF_READRXPDU_NOTIFY_STATUS_API must be enabled. */
-				#if(CanIfPublicReadRxPduNotifyStatusApi==STD_ON)
+				#if(CANIF_PUBLIC_READ_RX_PDU_NOTIFY_STATUS_API==STD_ON)
 					uint8 CanIfRxPduReadNotifyStatus;
 				#endif
 				
@@ -303,7 +303,7 @@ typedef struct{
 				are configured for receive indications and thus <User_RxIndication>()
 				shall not be called, CANIF_RXPDU_USERRXINDICATION_UL and
 				CANIF_RXPDU_USERRXINDICATION_NAME need not to be configured. */
-				uint8 CanIfRxPduUserRxIndicationUL;
+				CANIF_RX_PDU_USER_RX_INDICATION_UL CanIfRxPduUserRxIndicationUL;
 				
 				/* The HRH to which Rx L-PDU belongs to, is referred through this parameter.
 				dependency: This information has to be derived from the CAN Driver configuration.*/
@@ -312,7 +312,7 @@ typedef struct{
 				/* Reference to the "global" Pdu structure to allow harmonization of handle IDs in the COM-Stack.
 				//Pdu* CanIfRxPduRef;
 				will be configured in implementation */
-}CanIfRxPduCfg;
+}CanIfRxPduCfgType;
 
 typedef struct{
 				/* Lower CAN Identifier of a receive CAN L-PDU for identifier range
@@ -324,50 +324,50 @@ typedef struct{
 				definition, in which all CAN Ids are mapped to one PduId.
 				Range: 0 - 536870911 */
 				uint32 CanIfRxPduCanIdRangeUpperCanId;
-}CanIfRxPduCanIdRange;
+}CanIfRxPduCanIdRangeType;
 
 typedef struct{
 				/* This parameter defines the upper layer module to which the CheckTrcvWakeFlagIndication
 				from the Driver modules have to be routed. If CANIF_PUBLIC_PN_SUPPORT equals False, this
 				parameter shall not be configurable. */
-				#if(CanIfPublicPnSupport==STD_ON)
-					uint8 CanIfDispatchUserCheckTrcvWakeFlagIndicationUL;
+				#if(CANIF_PUBLIC_PN_SUPPORT==STD_ON)
+					CANIF_DISPATCH_USER_CHECK_TRCV_WAKE_FLAG_INDICATION_UL CanIfDispatchUserCheckTrcvWakeFlagIndicationUL;
 				#endif
 				
 				/* This parameter defines the upper layer module to which the ClearTrcvWufFlagIndication
 				from the Driver modules have to be routed. If CANIF_PUBLIC_PN_SUPPORT equals False, this
 				parameter shall not be configurable. dependency: CANIF_PUBLIC_PN_SUPPORT */
-				#if(CanIfPublicPnSupport==STD_ON)
-					uint8 CanIfDispatchUserClearTrcvWufFlagIndicationUL;
+				#if(CANIF_PUBLIC_PN_SUPPORT==STD_ON)
+					CANIF_DISPATCH_USER_CLEAR_TRCV_WUF_FLAG_INDICATION_UL CanIfDispatchUserClearTrcvWufFlagIndicationUL;
 				#endif
 				
 				/* This parameter defines the upper layer module to which the ClearTrcvWufFlagIndication
 				from the Driver modules have to be routed. If CANIF_PUBLIC_PN_SUPPORT equals False, this
 				parameter shall not be configurable. dependency: CANIF_PUBLIC_PN_SUPPORT */
-				#if(CanIfPublicPnSupport==STD_ON)
-					uint8 CanIfDispatchUserConfirmPnAvailabilityUL;
+				#if(CANIF_PUBLIC_PN_SUPPORT==STD_ON)
+					CANIF_DISPATCH_USER_CONFIRM_PN_AVAILABILITY_UL CanIfDispatchUserConfirmPnAvailabilityUL;
 				#endif
 				
 				/* This parameter defines the upper layer (UL) module to which the notifications of all
 				ControllerBusOff events from the CAN Driver modules have to be routed via <User_ControllerBusOff>.
 				There is no possibility to configure no upper layer (UL) module as the provider of <User_ControllerBusOff>.
 				dependency: CANIF_PUBLIC_PN_SUPPORT */
-				uint8 CanIfDispatchUserCtrlBusOffUL;
+				CANIF_DISPATCH_USER_CTRL_BUS_OFF_UL CanIfDispatchUserCtrlBusOffUL;
 				
 				/* This parameter defines the upper layer (UL) module to which the notifications of all ControllerTransition
 				events from the CAN Driver modules have to be routed via <User_ControllerModeIndication>. */
-				uint8 CanIfDispatchUserCtrlModeIndicationUL;
+				CANIF_DISPATCH_USER_CTRL_MODE_INDICATION_UL CanIfDispatchUserCtrlModeIndicationUL;
 				
 				/* This parameter defines the upper layer (UL) module to which the notifications of all TransceiverTransition
 				events from	the CAN Transceiver Driver modules have to be routed via <User_TrcvModeIndication>. If no UL module is configured, no upper	layer callback function will be called. */
-				uint8 CanIfDispatchUserTrcvModeIndicationUL;
+				CANIF_DISPATCH_USER_TRCV_MODE_INDICATION_UL CanIfDispatchUserTrcvModeIndicationUL;
 				
 				/* This parameter defines the upper layer (UL) module to which the notifications about positive former requested
 				wake up sources have to be routed via <User_ValidateWakeupEvent>. If parameter CANIF_WAKEUP_CHECK_VALIDATION_API is disabled, this parameter cannot be configured. dependency: CANIF_WAKEUP_CHECK_VALIDATION_API */
-				#if(CanIfPublicWakeupCheckValidSupport==STD_ON)
-					uint8 CanIfDispatchUserValidateWakeupEventUL;
+				#if(CANIF_PUBLIC_WAKEUP_CHECK_VALID_SUPPORT==STD_ON)
+					CANIF_DISPATCH_USER_VALIDATE_WAKEUP_EVENT_UL CanIfDispatchUserValidateWakeupEventUL;
 				#endif
-}CanIfDispatchCfg;
+}CanIfDispatchCfgType;
 
 typedef struct {
 				/*This parameter abstracts from the CAN Driver specific parameter
@@ -382,7 +382,7 @@ typedef struct {
 				container shall be referenced by this link: CanControllerId, CanWakeupSourceRef
 				Range: 0..max. number of underlying supported CAN controllers*/
 				CanController *CanIfCtrlCanCtrlRef;
-}CanIfCtrlCfg;
+}CanIfCtrlCfgType;
 
 typedef struct {
 				/*Description Reference to the Init Hoh Configuration*/
@@ -396,14 +396,14 @@ typedef struct {
 				/*This container contains the configuration (parameters) of an adressed CAN controller by
 				an underlying CAN Driver module. This container is configurable per CAN controller.*/	
 				CanIfCtrlCfg CanIfCtrlConfig;
-}CanIfCtrlDrvCfg;
+}CanIfCtrlDrvCfgType;
 
 typedef struct {
 				/*This container contains the configuration (parameters) of
 				one addressed CAN transceiver by the underlying CAN Transceiver Driver module.
 				For each CAN transceiver a seperate instance of this container has to be provided. */
 				CanIfTrcvCfg CanIfTrcvConfig;
-}CanIfTrcvDrvCfg
+}CanIfTrcvDrvCfgType;
 
 typedef struct {
 				/*This parameter abstracts from the CAN Transceiver Driver specific parameter Transceiver.
@@ -416,7 +416,7 @@ typedef struct {
 				CAN transceiver driver module to be served by the CAN Interface module.
 				Range: 0..max. number of underlying supported CAN transceivers*/
 				CanTrcvChannel* CanIfTrcvCanTrcvRef;
-}CanIfTrcvCfg;
+}CanIfTrcvCfgType;
 
 typedef struct{
 				/*This container contains configuration parameters for each hardware receive object (HRH).*/
@@ -424,7 +424,7 @@ typedef struct{
 
 				/*This container contains parameters related to each HTH.*/
 				CanIfHthCfg CanIfHthConfig;
-}CanIfInitHohCfg;
+}CanIfInitHohCfgType;
 
 typedef struct {
 				/*Reference to controller Id to which the HTH belongs to. A controller can contain one or more HTHs.*/
@@ -435,7 +435,7 @@ typedef struct {
 				- CanHandleType (see ECUC_Can_00323)
 				- CanObjectId (see ECUC_Can_00326) */
 				CanHardwareObject* CanIfHthIdSymRef;
-}CanIfHthCfg;
+}CanIfHthCfgType;
 
 typedef struct {
 				/*Reference to controller Id to which the HRH belongs to. A controller can contain one or more HRHs.*/	
@@ -446,7 +446,7 @@ typedef struct {
 	
 				/*Defines the parameters required for configurating multiple CANID ranges for a given same HRH.*/
 				CanIfHrhRangeCfg CanIfHrhRangeConfig;
-}CanIfHrhCfg;
+}CanIfHrhCfgType;
 
 typedef struct {
 				/*CAN Identifier used as base value in combination with CanIfHrhRangeMask for a masked ID range
@@ -465,12 +465,12 @@ typedef struct {
 				/*Specifies whether a configured Range of CAN Ids shall only consider standard CAN Ids or extended CAN Id
 				Range: 		EXTENDED All the CANIDs are of type extended only (29 bit).
 							STANDARD All the CANIDs are of type standard only (11bit). */
-				uint8 CanIfHrhRangeRxPduRangeCanIdType;
+				CANIF_HRH_RANGE_RX_PDU_RANGE_CAN_ID_TYPE CanIfHrhRangeRxPduRangeCanIdType;
 
 				/*Upper CAN Identifier of a receive CAN L-PDU for identifier range definition, in which all CAN Ids shall
 				pass the software filtering.*/
 				uint32 CanIfHrhRangeRxPduUpperCanId;
-}CanIfHrhRangeCfg;
+}CanIfHrhRangeCfgType;
 
 typedef struct {
 				/*This parameter defines the number of CanIf Tx L-PDUs which can be buffered in one Txbuffer. If this value
@@ -484,6 +484,6 @@ typedef struct {
 				All the CanIf Tx L-PDUs refer via the CanIfBufferCfg and this parameter to the HTHs if TxBuffering is enabled, or
 				not. Each HTH shall not be assigned to more than one buffer*/
 				CanIfHthCfg* CanIfBufferHthRef;
-}CanIfBufferCfg;
+}CanIfBufferCfgType;
 
 #endif /* __CANIF_H__ */

--- a/Software/bsw/static/COM/CanIf/inc/CanIf.h
+++ b/Software/bsw/static/COM/CanIf/inc/CanIf.h
@@ -42,34 +42,27 @@
 
 typedef struct {
 
-/*Configuration parameters for all the underlying CAN
-Driver modules are aggregated under this container.
-For each CAN Driver module a seperate instance of
-this container has to be provided.*/
-CanIfCtrlDrvCfgType CanIfCtrlDrvConfig;
+				/*Configuration parameters for all the underlying CAN Driver modules are aggregated under this container.
+				For each CAN Driver module a seperate instance of this container has to be provided.*/
+				CanIfCtrlDrvCfgType 	CanIfCtrlDrvCfgObj;
 				
-/*Callback functions provided by upper layer modules of
-the CanIf. The callback functions defined in this
-container are common to all configured CAN Driver /
-CAN Transceiver Driver modules.*/
-CanIfDispatchCfgType CanIfDispatchConfig;
+				/*Callback functions provided by upper layer modules of the CanIf. The callback functions defined in this
+				container are common to all configured CAN Driver / CAN Transceiver Driver modules.*/
+				CanIfDispatchCfgType	CanIfDispatchCfgObj;
 								
-/*This container contains the init parameters of the CAN Interface.*/
-CanIfInitCfgType	CanIfInitConfig;
+				/*This container contains the init parameters of the CAN Interface.*/
+				CanIfInitCfgType		CanIfInitCfgObj;
 				
-/*This container contains the private configuration (parameters) of the CAN Interface.*/
-CanIfPrivateCfgType   	CanIfPrivateConfig;
+				/*This container contains the private configuration (parameters) of the CAN Interface.*/
+				CanIfPrivateCfgType   	CanIfPrivateCfgObj;
 				
-/*This container contains the public configuration (parameters) of the CAN Interface.*/
-CanIfPublicCfgType		CanIfPublicConfig;
+				/*This container contains the public configuration (parameters) of the CAN Interface.*/
+				CanIfPublicCfgType		CanIfPublicCfgObj;
 
-/*This container contains the configuration (parameters)
-of all addressed CAN transceivers by each underlying
-CAN Transceiver Driver module. For each CAN
-transceiver Driver a seperate instance of this container
-shall be provided.*/            
-CanIfTrcvDrvCfgType    CanIfTrcvDrvConfig;   
-}CanIf;
+				/*This container contains the configuration (parameters) of all addressed CAN transceivers by each underlying CAN
+				Transceiver Driver module. For each CAN transceiver Driver a seperate instance of this container shall be provided.*/            
+				CanIfTrcvDrvCfgType		CanIfTrcvDrvCfgObj;   
+}CanIfType;
 
 typedef struct {
 				/*Selects the desired software filter mechanism for reception only. 
@@ -112,38 +105,23 @@ typedef struct {
 				Range: 0..18446744073709551615 */
 				uint64 CanIfMaxTxPduCfg;
 				
-				/**************************************************************************************************************
-																Included Containers 
-				**************************************************************************************************************/
-				
-				/* This container contains the Txbuffer configuration.
-				Multiple buffers with different sizes could be configured.
-				If CanIfBufferSize (ECUC_CanIf_00834) equals 0, the
-				CanIf Tx L-PDU only refers via this CanIfBufferCfg the
+				/* This container contains the Txbuffer configuration. Multiple buffers with different sizes could be configured.
+				If CanIfBufferSize (ECUC_CanIf_00834) equals 0, the CanIf Tx L-PDU only refers via this CanIfBufferCfg the
 				corresponding CanIfHthCfg. */
-				CanIfBufferCfgType	CanIfBufferConfig;
+				CanIfBufferCfgType	CanIfBufferCfgObj;
 				
-				/* This container contains the references to the
-				configuration setup of each underlying CAN Driver. */
-				CanIfInitHohCfgType	CanIfInitHohConfig;
+				/* This container contains the references to the configuration setup of each underlying CAN Driver. */
+				CanIfInitHohCfgType	CanIfInitHohCfgObj;
 				
-				/* This container contains the configuration (parameters)
-				of each receive CAN L-PDU.
-				The SHORT-NAME of "CanIfRxPduConfig" container
-				itself represents the symolic name of Receive L-PDU.
-				This L-SDU produces a meta data item of type
-				CAN_ID_32. */
-				CanIfRxPduCfgType	CanIfRxPduConfig;
+				/* This container contains the configuration (parameters) of each receive CAN L-PDU. The SHORT-NAME of
+				"CanIfRxPduConfig" container itself represents the symolic name of Receive L-PDU. This L-SDU produces
+				a meta data item of type CAN_ID_32. */
+				CanIfRxPduCfgType	CanIfRxPduCfgObj;
 				
-				/* This container contains the configuration (parameters)
-				of a transmit CAN L-PDU. It has to be configured as
-				often as a transmit CAN L-PDU is needed.
-				The SHORT-NAME of "CanIfTxPduConfig" container
-				represents the symolic name of Transmit L-PDU.
-				This L-SDU consumes a meta data item of type
-				CAN_ID_32. */
-				CanIfTxPduCfgType	CanIfTxPduConfig;
-				
+				/* This container contains the configuration (parameters) of a transmit CAN L-PDU. It has to be configured as
+				often as a transmit CAN L-PDU is needed. The SHORT-NAME of "CanIfTxPduConfig" container represents the symolic
+				name of Transmit L-PDU. This L-SDU consumes a meta data item of type CAN_ID_32. */
+				CanIfTxPduCfgType	CanIfTxPduCfgObj;
 }CanIfInitCfgType;
 
 typedef struct {
@@ -312,6 +290,9 @@ typedef struct{
 				/* Reference to the "global" Pdu structure to allow harmonization of handle IDs in the COM-Stack.
 				//Pdu* CanIfRxPduRef;
 				will be configured in implementation */
+				
+				/* Optional container that allows to map a range of CAN Ids to one PduId. */
+				CanIfRxPduCanIdRangeType CanIfRxPduCanIdRangeObj;
 }CanIfRxPduCfgType;
 
 typedef struct{
@@ -381,29 +362,22 @@ typedef struct {
 				Interface module. The following parameters of CanController config
 				container shall be referenced by this link: CanControllerId, CanWakeupSourceRef
 				Range: 0..max. number of underlying supported CAN controllers*/
-				CanControllerType *CanIfCtrlCanCtrlRef;
+				CanControllerType* CanIfCtrlCanCtrlRef;
 }CanIfCtrlCfgType;
 
 typedef struct {
 				/*Description Reference to the Init Hoh Configuration*/
-				CanIfInitHohCfgType *CanIfCtrlDrvInitHohConfigRef 	;
+				CanIfInitHohCfgType* CanIfCtrlDrvInitHohConfigRef 	;
 
 				/*CAN Interface Driver Reference.
 				This reference can be used to get any information (Ex. Driver Name, Vendor ID) from
 				the CAN driver. The CAN Driver name can be derived from the ShortName of the CAN driver module.*/
-				CanGeneralType * CanIfCtrlDrvNameRef;
+				CanGeneralType* CanIfCtrlDrvNameRef;
 
 				/*This container contains the configuration (parameters) of an adressed CAN controller by
 				an underlying CAN Driver module. This container is configurable per CAN controller.*/	
-				CanIfCtrlCfgType CanIfCtrlConfig;
+				CanIfCtrlCfgType CanIfCtrlCfgObj;
 }CanIfCtrlDrvCfgType;
-
-typedef struct {
-				/*This container contains the configuration (parameters) of
-				one addressed CAN transceiver by the underlying CAN Transceiver Driver module.
-				For each CAN transceiver a seperate instance of this container has to be provided. */
-				CanIfTrcvCfgType CanIfTrcvConfig;
-}CanIfTrcvDrvCfgType;
 
 typedef struct {
 				/*This parameter abstracts from the CAN Transceiver Driver specific parameter Transceiver.
@@ -418,13 +392,11 @@ typedef struct {
 				CanTrcvChannel* CanIfTrcvCanTrcvRef;
 }CanIfTrcvCfgType;
 
-typedef struct{
-				/*This container contains configuration parameters for each hardware receive object (HRH).*/
-				CanIfHrhCfgType CanIfHrhConfig;
-
-				/*This container contains parameters related to each HTH.*/
-				CanIfHthCfgType CanIfHthConfig;
-}CanIfInitHohCfgType;
+typedef struct {
+				/*This container contains the configuration (parameters) of one addressed CAN transceiver by the underlying CAN
+				Transceiver Driver module. For each CAN transceiver a seperate instance of this container has to be provided. */
+				CanIfTrcvCfgType CanIfTrcvCfgObj;
+}CanIfTrcvDrvCfgType;
 
 typedef struct {
 				/*Reference to controller Id to which the HTH belongs to. A controller can contain one or more HTHs.*/
@@ -436,17 +408,6 @@ typedef struct {
 				- CanObjectId (see ECUC_Can_00326) */
 				CanHardwareObjectType* CanIfHthIdSymRef;
 }CanIfHthCfgType;
-
-typedef struct {
-				/*Reference to controller Id to which the HRH belongs to. A controller can contain one or more HRHs.*/	
-				CanIfCtrlCfgType* CanIfHrhCanCtrlIdRef;
-
-				/*The parameter refers to a particular HRH object in the CanDrv configuration*/	
-				CanHardwareObjectType* CanIfHrhIdSymRef;
-	
-				/*Defines the parameters required for configurating multiple CANID ranges for a given same HRH.*/
-				CanIfHrhRangeCfgType CanIfHrhRangeConfig;
-}CanIfHrhCfgType;
 
 typedef struct {
 				/*CAN Identifier used as base value in combination with CanIfHrhRangeMask for a masked ID range
@@ -471,6 +432,25 @@ typedef struct {
 				pass the software filtering.*/
 				uint32 CanIfHrhRangeRxPduUpperCanId;
 }CanIfHrhRangeCfgType;
+
+typedef struct {
+				/*Reference to controller Id to which the HRH belongs to. A controller can contain one or more HRHs.*/	
+				CanIfCtrlCfgType* CanIfHrhCanCtrlIdRef;
+
+				/*The parameter refers to a particular HRH object in the CanDrv configuration*/	
+				CanHardwareObjectType* CanIfHrhIdSymRef;
+	
+				/*Defines the parameters required for configurating multiple CANID ranges for a given same HRH.*/
+				CanIfHrhRangeCfgType CanIfHrhRangeCfgObj;
+}CanIfHrhCfgType;
+
+typedef struct{
+				/*This container contains configuration parameters for each hardware receive object (HRH).*/
+				CanIfHrhCfgType CanIfHrhCfgObj;
+
+				/*This container contains parameters related to each HTH.*/
+				CanIfHthCfgType CanIfHthCfgObj;
+}CanIfInitHohCfgType;
 
 typedef struct {
 				/*This parameter defines the number of CanIf Tx L-PDUs which can be buffered in one Txbuffer. If this value

--- a/Software/bsw/static/COM/CanIf/inc/CanIf.h
+++ b/Software/bsw/static/COM/CanIf/inc/CanIf.h
@@ -46,29 +46,29 @@ typedef struct {
 Driver modules are aggregated under this container.
 For each CAN Driver module a seperate instance of
 this container has to be provided.*/
-CanIfCtrlDrvCfg CanIfCtrlDrvConfig;
+CanIfCtrlDrvCfgType CanIfCtrlDrvConfig;
 				
 /*Callback functions provided by upper layer modules of
 the CanIf. The callback functions defined in this
 container are common to all configured CAN Driver /
 CAN Transceiver Driver modules.*/
-CanIfDispatchCfg CanIfDispatchConfig;
+CanIfDispatchCfgType CanIfDispatchConfig;
 								
 /*This container contains the init parameters of the CAN Interface.*/
-CanIfInitCfg	CanIfInitConfig;
+CanIfInitCfgType	CanIfInitConfig;
 				
 /*This container contains the private configuration (parameters) of the CAN Interface.*/
-CanIfPrivateCfg   	CanIfPrivateConfig;
+CanIfPrivateCfgType   	CanIfPrivateConfig;
 				
 /*This container contains the public configuration (parameters) of the CAN Interface.*/
-CanIfPublicCfg		CanIfPublicConfig;
+CanIfPublicCfgType		CanIfPublicConfig;
 
 /*This container contains the configuration (parameters)
 of all addressed CAN transceivers by each underlying
 CAN Transceiver Driver module. For each CAN
 transceiver Driver a seperate instance of this container
 shall be provided.*/            
-CanIfTrcvDrvCfg    CanIfTrcvDrvConfig;   
+CanIfTrcvDrvCfgType    CanIfTrcvDrvConfig;   
 }CanIf;
 
 typedef struct {
@@ -121,11 +121,11 @@ typedef struct {
 				If CanIfBufferSize (ECUC_CanIf_00834) equals 0, the
 				CanIf Tx L-PDU only refers via this CanIfBufferCfg the
 				corresponding CanIfHthCfg. */
-				CanIfBufferCfg	CanIfBufferConfig;
+				CanIfBufferCfgType	CanIfBufferConfig;
 				
 				/* This container contains the references to the
 				configuration setup of each underlying CAN Driver. */
-				CanIfInitHohCfg	CanIfInitHohConfig;
+				CanIfInitHohCfgType	CanIfInitHohConfig;
 				
 				/* This container contains the configuration (parameters)
 				of each receive CAN L-PDU.
@@ -133,7 +133,7 @@ typedef struct {
 				itself represents the symolic name of Receive L-PDU.
 				This L-SDU produces a meta data item of type
 				CAN_ID_32. */
-				CanIfRxPduCfg	CanIfRxPduConfig;
+				CanIfRxPduCfgType	CanIfRxPduConfig;
 				
 				/* This container contains the configuration (parameters)
 				of a transmit CAN L-PDU. It has to be configured as
@@ -142,7 +142,7 @@ typedef struct {
 				represents the symolic name of Transmit L-PDU.
 				This L-SDU consumes a meta data item of type
 				CAN_ID_32. */
-				CanIfTxPduCfg	CanIfTxPduConfig;
+				CanIfTxPduCfgType	CanIfTxPduConfig;
 				
 }CanIfInitCfgType;
 
@@ -227,7 +227,7 @@ typedef struct {
 				#endif
 				
 				/* Configurable reference to a CanIf buffer configuration. CanIfBufferCfg */
-				CanIfBufferCfg* CanIfTxPduBufferRef;
+				CanIfBufferCfgType* CanIfTxPduBufferRef;
 				
 				/* Reference to the "global" Pdu structure to allow harmonization of handle IDs in the COM-Stack.
 				//Pdu* CanIfTxPduRef;
@@ -307,7 +307,7 @@ typedef struct{
 				
 				/* The HRH to which Rx L-PDU belongs to, is referred through this parameter.
 				dependency: This information has to be derived from the CAN Driver configuration.*/
-				CanIfHrhCfg* CanIfRxPduHrhIdRef;
+				CanIfHrhCfgType* CanIfRxPduHrhIdRef;
 				
 				/* Reference to the "global" Pdu structure to allow harmonization of handle IDs in the COM-Stack.
 				//Pdu* CanIfRxPduRef;
@@ -381,28 +381,28 @@ typedef struct {
 				Interface module. The following parameters of CanController config
 				container shall be referenced by this link: CanControllerId, CanWakeupSourceRef
 				Range: 0..max. number of underlying supported CAN controllers*/
-				CanController *CanIfCtrlCanCtrlRef;
+				CanControllerType *CanIfCtrlCanCtrlRef;
 }CanIfCtrlCfgType;
 
 typedef struct {
 				/*Description Reference to the Init Hoh Configuration*/
-				CanIfInitHohCfg *CanIfCtrlDrvInitHohConfigRef 	;
+				CanIfInitHohCfgType *CanIfCtrlDrvInitHohConfigRef 	;
 
 				/*CAN Interface Driver Reference.
 				This reference can be used to get any information (Ex. Driver Name, Vendor ID) from
 				the CAN driver. The CAN Driver name can be derived from the ShortName of the CAN driver module.*/
-				CanGeneral * CanIfCtrlDrvNameRef;
+				CanGeneralType * CanIfCtrlDrvNameRef;
 
 				/*This container contains the configuration (parameters) of an adressed CAN controller by
 				an underlying CAN Driver module. This container is configurable per CAN controller.*/	
-				CanIfCtrlCfg CanIfCtrlConfig;
+				CanIfCtrlCfgType CanIfCtrlConfig;
 }CanIfCtrlDrvCfgType;
 
 typedef struct {
 				/*This container contains the configuration (parameters) of
 				one addressed CAN transceiver by the underlying CAN Transceiver Driver module.
 				For each CAN transceiver a seperate instance of this container has to be provided. */
-				CanIfTrcvCfg CanIfTrcvConfig;
+				CanIfTrcvCfgType CanIfTrcvConfig;
 }CanIfTrcvDrvCfgType;
 
 typedef struct {
@@ -420,32 +420,32 @@ typedef struct {
 
 typedef struct{
 				/*This container contains configuration parameters for each hardware receive object (HRH).*/
-				CanIfHrhCfg CanIfHrhConfig;
+				CanIfHrhCfgType CanIfHrhConfig;
 
 				/*This container contains parameters related to each HTH.*/
-				CanIfHthCfg CanIfHthConfig;
+				CanIfHthCfgType CanIfHthConfig;
 }CanIfInitHohCfgType;
 
 typedef struct {
 				/*Reference to controller Id to which the HTH belongs to. A controller can contain one or more HTHs.*/
-				CanIfCtrlCfg* CanIfHthCanCtrlIdRef;
+				CanIfCtrlCfgType* CanIfHthCanCtrlIdRef;
 
 				/*The parameter refers to a particular HTH object in the CanDrv configuration (see CanHardwareObject 
 				ECUC_Can_00324). CanIf receives the following information of the CanDrv module by this reference:
 				- CanHandleType (see ECUC_Can_00323)
 				- CanObjectId (see ECUC_Can_00326) */
-				CanHardwareObject* CanIfHthIdSymRef;
+				CanHardwareObjectType* CanIfHthIdSymRef;
 }CanIfHthCfgType;
 
 typedef struct {
 				/*Reference to controller Id to which the HRH belongs to. A controller can contain one or more HRHs.*/	
-				CanIfCtrlCfg* CanIfHrhCanCtrlIdRef;
+				CanIfCtrlCfgType* CanIfHrhCanCtrlIdRef;
 
 				/*The parameter refers to a particular HRH object in the CanDrv configuration*/	
-				CanHardwareObject* CanIfHrhIdSymRef;
+				CanHardwareObjectType* CanIfHrhIdSymRef;
 	
 				/*Defines the parameters required for configurating multiple CANID ranges for a given same HRH.*/
-				CanIfHrhRangeCfg CanIfHrhRangeConfig;
+				CanIfHrhRangeCfgType CanIfHrhRangeConfig;
 }CanIfHrhCfgType;
 
 typedef struct {
@@ -483,7 +483,7 @@ typedef struct {
 				/*Reference to HTH, that defines the hardware object or the pool of hardware objects configured for transmission.
 				All the CanIf Tx L-PDUs refer via the CanIfBufferCfg and this parameter to the HTHs if TxBuffering is enabled, or
 				not. Each HTH shall not be assigned to more than one buffer*/
-				CanIfHthCfg* CanIfBufferHthRef;
+				CanIfHthCfgType* CanIfBufferHthRef;
 }CanIfBufferCfgType;
 
 #endif /* __CANIF_H__ */

--- a/Software/bsw/static/COM/CanIf/inc/CanIf.h
+++ b/Software/bsw/static/COM/CanIf/inc/CanIf.h
@@ -44,7 +44,7 @@ typedef struct {
 
 				/*Configuration parameters for all the underlying CAN Driver modules are aggregated under this container.
 				For each CAN Driver module a seperate instance of this container has to be provided.*/
-				CanIfCtrlDrvCfgType 	CanIfCtrlDrvCfgObj;
+				CanIfCtrlDrvCfgType 	CanIfCtrlDrvCfgObj[CAN_DRIVER_NUM];
 				
 				/*Callback functions provided by upper layer modules of the CanIf. The callback functions defined in this
 				container are common to all configured CAN Driver / CAN Transceiver Driver modules.*/
@@ -61,7 +61,7 @@ typedef struct {
 
 				/*This container contains the configuration (parameters) of all addressed CAN transceivers by each underlying CAN
 				Transceiver Driver module. For each CAN transceiver Driver a seperate instance of this container shall be provided.*/            
-				CanIfTrcvDrvCfgType		CanIfTrcvDrvCfgObj;   
+				CanIfTrcvDrvCfgType		CanIfTrcvDrvCfgObj[CAN_TRANSCEIVER_NUM];   
 }CanIfType;
 
 typedef struct {
@@ -108,20 +108,20 @@ typedef struct {
 				/* This container contains the Txbuffer configuration. Multiple buffers with different sizes could be configured.
 				If CanIfBufferSize (ECUC_CanIf_00834) equals 0, the CanIf Tx L-PDU only refers via this CanIfBufferCfg the
 				corresponding CanIfHthCfg. */
-				CanIfBufferCfgType	CanIfBufferCfgObj;
+				CanIfBufferCfgType	CanIfBufferCfgObj[BUFFERS_NUM];
 				
 				/* This container contains the references to the configuration setup of each underlying CAN Driver. */
-				CanIfInitHohCfgType	CanIfInitHohCfgObj;
+				CanIfInitHohCfgType	CanIfInitHohCfgObj[CAN_DRIVER_NUM];
 				
 				/* This container contains the configuration (parameters) of each receive CAN L-PDU. The SHORT-NAME of
 				"CanIfRxPduConfig" container itself represents the symolic name of Receive L-PDU. This L-SDU produces
 				a meta data item of type CAN_ID_32. */
-				CanIfRxPduCfgType	CanIfRxPduCfgObj;
+				CanIfRxPduCfgType	CanIfRxPduCfgObj[RX_CAN_L-PDU_NUM];
 				
 				/* This container contains the configuration (parameters) of a transmit CAN L-PDU. It has to be configured as
 				often as a transmit CAN L-PDU is needed. The SHORT-NAME of "CanIfTxPduConfig" container represents the symolic
 				name of Transmit L-PDU. This L-SDU consumes a meta data item of type CAN_ID_32. */
-				CanIfTxPduCfgType	CanIfTxPduCfgObj;
+				CanIfTxPduCfgType	CanIfTxPduCfgObj[TX_CAN_L-PDU_NUM];
 }CanIfInitCfgType;
 
 typedef struct {
@@ -395,7 +395,7 @@ typedef struct {
 typedef struct {
 				/*This container contains the configuration (parameters) of one addressed CAN transceiver by the underlying CAN
 				Transceiver Driver module. For each CAN transceiver a seperate instance of this container has to be provided. */
-				CanIfTrcvCfgType CanIfTrcvCfgObj;
+				CanIfTrcvCfgType CanIfTrcvCfgObj[CAN_TRANSCEIVER_NUM];
 }CanIfTrcvDrvCfgType;
 
 typedef struct {
@@ -441,15 +441,15 @@ typedef struct {
 				CanHardwareObjectType* CanIfHrhIdSymRef;
 	
 				/*Defines the parameters required for configurating multiple CANID ranges for a given same HRH.*/
-				CanIfHrhRangeCfgType CanIfHrhRangeCfgObj;
+				CanIfHrhRangeCfgType CanIfHrhRangeCfgObj[CANID_RANGES_NUM];
 }CanIfHrhCfgType;
 
 typedef struct{
 				/*This container contains configuration parameters for each hardware receive object (HRH).*/
-				CanIfHrhCfgType CanIfHrhCfgObj;
+				CanIfHrhCfgType CanIfHrhCfgObj[HRH_OBj_NUM];
 
 				/*This container contains parameters related to each HTH.*/
-				CanIfHthCfgType CanIfHthCfgObj;
+				CanIfHthCfgType CanIfHthCfgObj[HTH_OBj_NUM];
 }CanIfInitHohCfgType;
 
 typedef struct {

--- a/Software/bsw/static/COM/CanIf/inc/CanIf.h
+++ b/Software/bsw/static/COM/CanIf/inc/CanIf.h
@@ -80,6 +80,12 @@ typedef struct {
 				case of CDDs. Range of characters is 1.. 32. 
 				Type: EcucStringParamDef*/
 				uint8 CanIfPublicCddHeaderFile[CANIF_PUBLIC_CDD_HEADER_FILE];
+				
+				/* This parameter is used to configure the Can_HwHandleType. The
+				Can_HwHandleType represents the hardware object handles of a CAN
+				hardware unit. For CAN hardware units with more than 255 HW objects
+				the extended range shall be used (UINT16). */
+				CanIfPublicHandleTypeEnumType CanIfPublicHandleTypeEnum;
 }CanIfPublicCfgType;
  
 typedef struct {
@@ -376,7 +382,7 @@ typedef struct {
 
 				/*This container contains the configuration (parameters) of an adressed CAN controller by
 				an underlying CAN Driver module. This container is configurable per CAN controller.*/	
-				CanIfCtrlCfgType CanIfCtrlCfgObj;
+				CanIfCtrlCfgType CanIfCtrlCfgObj;//It should be CanIfCtrlCfgType CanIfCtrlCfgObj[MAX_CONFIGURABLE_CAN_CONTROLLERS];
 }CanIfCtrlDrvCfgType;
 
 typedef struct {

--- a/Software/bsw/static/COM/CanIf/inc/CanIf.h
+++ b/Software/bsw/static/COM/CanIf/inc/CanIf.h
@@ -72,7 +72,7 @@ typedef struct {
 						INDEX 	Selects Index Filter method.
 						LINEAR 	Selects Linear Filter method.
 						TABLE 	Selects Table Filter method.*/
-				CANIF_PRIVATE_SOFTWARE_FILTER_TYPE  CanIfPrivateSoftwareFilterType;
+				CanIfPrivateSoftwareFilterTypeType  CanIfPrivateSoftwareFilterType;
 }CanIfPrivateCfgType;
 
 typedef struct {
@@ -145,7 +145,7 @@ typedef struct {
 						EXTENDED_FD_CAN CAN FD 	frame with extended identifier (29 bits)
 						STANDARD_CAN CAN 		frame with standard identifier (11 bits)
 						STANDARD_FD_CAN CAN FD 	frame with standard identifier (11 bits) */
-				CANIF_TX_PDU_CAN_ID_TYPE CanIfTxPduCanIdType;
+				CanIfTxPduCanIdTypeType CanIfTxPduCanIdType;
 				
 				/* ECU wide unique, symbolic handle for transmit CAN L-SDU.
 				Range: 0..max. number of CantTxPduIds */
@@ -180,7 +180,7 @@ typedef struct {
 				/* Defines the type of each transmit CAN L-PDU.
 				Range:	DYNAMIC 	CAN ID is defined at runtime.
 						STATIC 		CAN ID is defined at compile-time. */
-				CANIF_TX_PDU_TYPE CanIfTxPduType;
+				CanIfTxPduTypeType CanIfTxPduType;
 				
 				/* This parameter defines the upper layer (UL) module to which the confirmation of
 				the successfully transmitted CANTXPDUID has to be routed via the <User_TxConfirmation>.
@@ -201,7 +201,7 @@ typedef struct {
 				<User_TriggerTransmit>() will not be called and CanIfTxPduUserTxConfirmationUL
 				as well as CanIfTxPduUserTriggerTransmitName need not to be configured. */
 				#if(CANIF_TXPDU_TRIGGERTRANSMIT==STD_ON)
-					CANIF_TX_PDU_USER_TX_CONFIRMATION_UL CanIfTxPduUserTxConfirmationUL;
+					CanIfTxPduUserTxConfirmationULType CanIfTxPduUserTxConfirmationUL;
 				#endif
 				
 				/* Configurable reference to a CanIf buffer configuration. CanIfBufferCfg */
@@ -235,7 +235,7 @@ typedef struct{
 						STANDARD_CAN 			CAN 2.0 or CAN FD frame with standard identifier (11 bits)
 						STANDARD_FD_CAN 		CAN FD frame with standard identifier (11 bits)
 						STANDARD_NO_FD_CAN 		CAN 2.0 frame with standard identifier (11 bits) */
-				CANIF_RX_PDU_CAN_ID_TYPE CanIfRxPduCanIdType;
+				CanIfRxPduCanIdTypeType CanIfRxPduCanIdType;
 				
 				/* Data length of the received CAN L-PDUs used by the CAN Interface.
 				This information is used for Data Length Check. Additionally it might
@@ -281,7 +281,7 @@ typedef struct{
 				are configured for receive indications and thus <User_RxIndication>()
 				shall not be called, CANIF_RXPDU_USERRXINDICATION_UL and
 				CANIF_RXPDU_USERRXINDICATION_NAME need not to be configured. */
-				CANIF_RX_PDU_USER_RX_INDICATION_UL CanIfRxPduUserRxIndicationUL;
+				CanIfRxPduUserRxIndicationULType CanIfRxPduUserRxIndicationUL;
 				
 				/* The HRH to which Rx L-PDU belongs to, is referred through this parameter.
 				dependency: This information has to be derived from the CAN Driver configuration.*/
@@ -312,41 +312,41 @@ typedef struct{
 				from the Driver modules have to be routed. If CANIF_PUBLIC_PN_SUPPORT equals False, this
 				parameter shall not be configurable. */
 				#if(CANIF_PUBLIC_PN_SUPPORT==STD_ON)
-					CANIF_DISPATCH_USER_CHECK_TRCV_WAKE_FLAG_INDICATION_UL CanIfDispatchUserCheckTrcvWakeFlagIndicationUL;
+					CanIfDispatchUserCheckTrcvWakeFlagIndicationULType CanIfDispatchUserCheckTrcvWakeFlagIndicationUL;
 				#endif
 				
 				/* This parameter defines the upper layer module to which the ClearTrcvWufFlagIndication
 				from the Driver modules have to be routed. If CANIF_PUBLIC_PN_SUPPORT equals False, this
 				parameter shall not be configurable. dependency: CANIF_PUBLIC_PN_SUPPORT */
 				#if(CANIF_PUBLIC_PN_SUPPORT==STD_ON)
-					CANIF_DISPATCH_USER_CLEAR_TRCV_WUF_FLAG_INDICATION_UL CanIfDispatchUserClearTrcvWufFlagIndicationUL;
+					CanIfDispatchUserClearTrcvWufFlagIndicationULType CanIfDispatchUserClearTrcvWufFlagIndicationUL;
 				#endif
 				
 				/* This parameter defines the upper layer module to which the ClearTrcvWufFlagIndication
 				from the Driver modules have to be routed. If CANIF_PUBLIC_PN_SUPPORT equals False, this
 				parameter shall not be configurable. dependency: CANIF_PUBLIC_PN_SUPPORT */
 				#if(CANIF_PUBLIC_PN_SUPPORT==STD_ON)
-					CANIF_DISPATCH_USER_CONFIRM_PN_AVAILABILITY_UL CanIfDispatchUserConfirmPnAvailabilityUL;
+					CanIfDispatchUserConfirmPnAvailabilityULType CanIfDispatchUserConfirmPnAvailabilityUL;
 				#endif
 				
 				/* This parameter defines the upper layer (UL) module to which the notifications of all
 				ControllerBusOff events from the CAN Driver modules have to be routed via <User_ControllerBusOff>.
 				There is no possibility to configure no upper layer (UL) module as the provider of <User_ControllerBusOff>.
 				dependency: CANIF_PUBLIC_PN_SUPPORT */
-				CANIF_DISPATCH_USER_CTRL_BUS_OFF_UL CanIfDispatchUserCtrlBusOffUL;
+				CanIfDispatchUserCtrlBusOffULType CanIfDispatchUserCtrlBusOffUL;
 				
 				/* This parameter defines the upper layer (UL) module to which the notifications of all ControllerTransition
 				events from the CAN Driver modules have to be routed via <User_ControllerModeIndication>. */
-				CANIF_DISPATCH_USER_CTRL_MODE_INDICATION_UL CanIfDispatchUserCtrlModeIndicationUL;
+				CanIfDispatchUserCtrlModeIndicationULType CanIfDispatchUserCtrlModeIndicationUL;
 				
 				/* This parameter defines the upper layer (UL) module to which the notifications of all TransceiverTransition
 				events from	the CAN Transceiver Driver modules have to be routed via <User_TrcvModeIndication>. If no UL module is configured, no upper	layer callback function will be called. */
-				CANIF_DISPATCH_USER_TRCV_MODE_INDICATION_UL CanIfDispatchUserTrcvModeIndicationUL;
+				CanIfDispatchUserTrcvModeIndicationULType CanIfDispatchUserTrcvModeIndicationUL;
 				
 				/* This parameter defines the upper layer (UL) module to which the notifications about positive former requested
 				wake up sources have to be routed via <User_ValidateWakeupEvent>. If parameter CANIF_WAKEUP_CHECK_VALIDATION_API is disabled, this parameter cannot be configured. dependency: CANIF_WAKEUP_CHECK_VALIDATION_API */
 				#if(CANIF_PUBLIC_WAKEUP_CHECK_VALID_SUPPORT==STD_ON)
-					CANIF_DISPATCH_USER_VALIDATE_WAKEUP_EVENT_UL CanIfDispatchUserValidateWakeupEventUL;
+					CanIfDispatchUserValidateWakeupEventULType CanIfDispatchUserValidateWakeupEventUL;
 				#endif
 }CanIfDispatchCfgType;
 
@@ -426,7 +426,7 @@ typedef struct {
 				/*Specifies whether a configured Range of CAN Ids shall only consider standard CAN Ids or extended CAN Id
 				Range: 		EXTENDED All the CANIDs are of type extended only (29 bit).
 							STANDARD All the CANIDs are of type standard only (11bit). */
-				CANIF_HRH_RANGE_RX_PDU_RANGE_CAN_ID_TYPE CanIfHrhRangeRxPduRangeCanIdType;
+				CanIfHrhRangeRxPduRangeCanIdTypeType CanIfHrhRangeRxPduRangeCanIdType;
 
 				/*Upper CAN Identifier of a receive CAN L-PDU for identifier range definition, in which all CAN Ids shall
 				pass the software filtering.*/

--- a/Software/bsw/static/COM/CanIf/inc/CanIf.h
+++ b/Software/bsw/static/COM/CanIf/inc/CanIf.h
@@ -37,6 +37,7 @@
 
 #include "CanIf_Types.h"
 #include "CanIf_Cfg.h"
+#include "Can.h"
 
 
 
@@ -382,7 +383,7 @@ typedef struct {
 
 				/*This container contains the configuration (parameters) of an adressed CAN controller by
 				an underlying CAN Driver module. This container is configurable per CAN controller.*/	
-				CanIfCtrlCfgType CanIfCtrlCfgObj;//It should be CanIfCtrlCfgType CanIfCtrlCfgObj[MAX_CONFIGURABLE_CAN_CONTROLLERS];
+				CanIfCtrlCfgType CanIfCtrlCfgObj;//To Do: It should be CanIfCtrlCfgType CanIfCtrlCfgObj[USED_CONTROLLERS_NUMBER];
 }CanIfCtrlDrvCfgType;
 
 typedef struct {

--- a/Software/bsw/static/COM/CanIf/inc/CanIf_Types.h
+++ b/Software/bsw/static/COM/CanIf/inc/CanIf_Types.h
@@ -77,8 +77,9 @@
 	is necessary for initialization.
 	The contents of the initialization data structure are CAN interface specific	
 */
-typedef struct CanIf_Config
+typedef struct 
 {
+			   CanIfType CanIfTypeObj;
 
 }CanIf_ConfigType;
 


### PR DESCRIPTION
Made Modifications to follow our last meeting notes.
Meeting Notes:
1- Add word to the suffix of each struct name, to follow the AUTOSAR naming convention

2- All #defines are in UpperCase, whether it's a pre-compile parameter or not, and with underscores between each word (after the module name)
Example: _DISPATCH_USER_CHECK_TRCV_WAKE_FLAG_INDICATION_UL

3- Variables are in LowerCase with it's first letter in UpperCase

4- Data type of enum paramters in the structure has to be the same as the defined in the Cfg file
Example:
typedef uint8 CANIF_DISPATCH_USER_CTRL_BUS_OFF_UL;
#define CAN_SM ((CANIF_DISPATCH_USER_CTRL_BUS_OFF_UL)0x00)
#define CDD ((CANIF_DISPATCH_USER_CTRL_BUS_OFF_UL)0x01)
typedef struct{
CANIF_DISPATCH_USER_CTRL_BUS_OFF_UL CanIfDispatchUserCtrlBusOffUL;
}CanIfDispatchCfgType;

5- Function names that will be passed, should be without ()
Example:
#if(CANIF_DISPATCH_USER_CTRL_BUS_OFF_UL==CAN_SM)
#define CANIF_DISPATCH__USER_CTRL_BUS_OFF_NAME CanSM_ControllerBusOff /* no ( ) at the end of the function name /
#else if(CANIF_DISPATCH_USER_CTRL_BUS_OFF_UL==CDD)
#define CANIF_DISPATCH__USER_CTRL_BUS_OFF_NAME Cdd_ControllerBusOff / no ( ) at the end of the function name */
#endif

6- PostBuild paramaters that has variables in the struct don't need to make a #define for its init value, it's value will be assigned from the PostBuild file (in the struct object)

Side Note:

PostBuild paramaters can be #defines only without structs.....depends on what we agreed for implementation